### PR TITLE
Fix sending auth token

### DIFF
--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -67,7 +67,10 @@ export async function wrapApiResponse<
 
 const api = new Api<string>({
   baseUrl: ENV.CHAEKIT_API_ENDPOINT,
-  securityWorker: (accessToken) => {
+  baseApiParams: {
+    secure: true,
+  },
+  securityWorker: async (accessToken) => {
     return {
       headers: {
         ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),

--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -73,7 +73,7 @@ const api = new Api<string>({
   securityWorker: async (accessToken) => {
     return {
       headers: {
-        ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+        ...(accessToken ? { Authorization: accessToken } : {}),
       },
     };
   },


### PR DESCRIPTION
## ✨ 작업 개요
api 요청 시 액세스 토큰 전달이 불가능한 현상을 수정합니다

## ✅ 작업 내용
- API 클라이언트 보안 설정 켜기
- 중복된 토큰에 접두어 제거

## 📎 관련 이슈

## 🧪 테스트 방법

## 💬 기타
