### PR TITLE
[CHORE] 클라이언트 배포 시 CF 캐시 무효화 실행

### DIFF
--- a/client/cdk/lib/ClientDeploymentStack.ts
+++ b/client/cdk/lib/ClientDeploymentStack.ts
@@ -30,12 +30,6 @@ export class ClientDeploymentStack extends cdk.Stack {
     });
 
     // ==============================================================
-    new cdk.aws_s3_deployment.BucketDeployment(this, "DeployClient", {
-      sources: [cdk.aws_s3_deployment.Source.asset("../dist")],
-      destinationBucket: bucket,
-    });
-
-    // ==============================================================
     const zone = cdk.aws_route53.HostedZone.fromHostedZoneAttributes(
       this,
       "Zone",
@@ -83,6 +77,14 @@ export class ClientDeploymentStack extends cdk.Stack {
         domainNames: [clientDomainName],
       }
     );
+
+    // ==============================================================
+    new cdk.aws_s3_deployment.BucketDeployment(this, "DeployClient", {
+      sources: [cdk.aws_s3_deployment.Source.asset("../dist")],
+      destinationBucket: bucket,
+      distribution: cloudFront,
+      distributionPaths: ["/*"],
+    });
 
     // ==============================================================
     new cdk.aws_route53.ARecord(this, "ClientRecord", {

--- a/client/src/routes/_pathlessLayout/login.tsx
+++ b/client/src/routes/_pathlessLayout/login.tsx
@@ -35,7 +35,6 @@ function RouteComponent() {
 
     if (!response.isSuccessful) {
       // TODO: Handle error
-      console.error("Test invalidation");
       return;
     }
 

--- a/client/src/routes/_pathlessLayout/login.tsx
+++ b/client/src/routes/_pathlessLayout/login.tsx
@@ -35,6 +35,7 @@ function RouteComponent() {
 
     if (!response.isSuccessful) {
       // TODO: Handle error
+      console.error("Test invalidation");
       return;
     }
 


### PR DESCRIPTION
## ✨ 작업 개요
클라이언트 배포 시 CF 캐시 무효화 실행

## ✅ 작업 내용
- 클라이언트 배포 시 CF 캐시 무효화 실행
  - 캐시가 무효화가 실행되지않아 예전 js파일을 가져오려는 문제가 있었음

## 📎 관련 이슈

## 🧪 테스트 방법

## 💬 기타
