### PR TITLE
[Refactor] jwt 구조 변경 및 @Login 기능 변경

### DIFF
--- a/chaekit-spring/README.md
+++ b/chaekit-spring/README.md
@@ -9,11 +9,13 @@
 3. Docker 컨테이너 실행
    ```bash
    # 백그라운드 실행
-   docker compose up -d
+   docker compose up -d --build
    # 정상 작동 확인
    docker compose ps
    # 정지
    docker compose down
+   # 기존 db와 충돌되는 경우
+   docker-compose down -v
    ```
 
 ## 🐬 MySQL 설정

--- a/chaekit-spring/src/main/java/qwerty/chaekit/controller/ebook/EbookController.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/controller/ebook/EbookController.java
@@ -1,14 +1,24 @@
 package qwerty.chaekit.controller.ebook;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import qwerty.chaekit.dto.ebook.EbookFetchResponse;
+import qwerty.chaekit.dto.page.PageResponse;
 import qwerty.chaekit.global.response.ApiSuccessResponse;
+import qwerty.chaekit.service.ebook.EbookService;
 
 @RestController
-@RequestMapping("/api/ebook")
+@RequestMapping("/api/books")
 @RequiredArgsConstructor
 public class EbookController {
-    @GetMapping("/api")
-    public ApiSuccessResponse<String> mainApi() {
-        return ApiSuccessResponse.of("Welcome to Chaekit");
+    public final EbookService ebookService;
+
+    @GetMapping
+    public ApiSuccessResponse<PageResponse<EbookFetchResponse>>getBooks(@ParameterObject Pageable pageable) {
+        return ApiSuccessResponse.of(ebookService.fetchEbookList(pageable));
     }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/controller/group/ActivityController.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/controller/group/ActivityController.java
@@ -12,7 +12,7 @@ import qwerty.chaekit.dto.group.activity.ActivityPostResponse;
 import qwerty.chaekit.dto.page.PageResponse;
 import qwerty.chaekit.global.response.ApiSuccessResponse;
 import qwerty.chaekit.global.security.resolver.Login;
-import qwerty.chaekit.global.security.resolver.LoginMember;
+import qwerty.chaekit.global.security.resolver.UserToken;
 import qwerty.chaekit.service.group.ActivityService;
 
 @RestController
@@ -22,10 +22,10 @@ public class ActivityController {
     private final ActivityService activityService;
 
     @PostMapping
-    public ApiSuccessResponse<ActivityPostResponse> createActivity(@Login LoginMember loginMember,
+    public ApiSuccessResponse<ActivityPostResponse> createActivity(@Login UserToken userToken,
                                                                    @PathVariable long groupId,
                                                                    @RequestBody @Valid ActivityPostRequest activityPostRequest) {
-        return ApiSuccessResponse.of(activityService.createActivity(loginMember, groupId, activityPostRequest));
+        return ApiSuccessResponse.of(activityService.createActivity(userToken, groupId, activityPostRequest));
     }
 
     @GetMapping
@@ -35,10 +35,10 @@ public class ActivityController {
     }
 
     @PatchMapping
-    public ApiSuccessResponse<ActivityPostResponse> updateActivity(@Login LoginMember loginMember,
+    public ApiSuccessResponse<ActivityPostResponse> updateActivity(@Login UserToken userToken,
                                          @PathVariable long groupId,
                                          @RequestBody @Valid ActivityPatchRequest request) {
-        return ApiSuccessResponse.of(activityService.updateActivity(loginMember, groupId, request));
+        return ApiSuccessResponse.of(activityService.updateActivity(userToken, groupId, request));
     }
 
 

--- a/chaekit-spring/src/main/java/qwerty/chaekit/controller/group/GroupController.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/controller/group/GroupController.java
@@ -8,7 +8,7 @@ import qwerty.chaekit.dto.group.*;
 import qwerty.chaekit.dto.page.PageResponse;
 import qwerty.chaekit.global.response.ApiSuccessResponse;
 import qwerty.chaekit.global.security.resolver.Login;
-import qwerty.chaekit.global.security.resolver.LoginMember;
+import qwerty.chaekit.global.security.resolver.UserToken;
 import qwerty.chaekit.service.group.GroupService;
 
 @RestController
@@ -18,9 +18,9 @@ public class GroupController {
     private final GroupService groupService;
 
     @PostMapping
-    public ApiSuccessResponse<GroupPostResponse> createGroup(@Login LoginMember loginMember,
+    public ApiSuccessResponse<GroupPostResponse> createGroup(@Login UserToken userToken,
                                          @RequestBody GroupPostRequest groupPostRequest) {
-        return ApiSuccessResponse.of(groupService.createGroup(loginMember, groupPostRequest));
+        return ApiSuccessResponse.of(groupService.createGroup(userToken, groupPostRequest));
     }
 
     @GetMapping
@@ -34,10 +34,10 @@ public class GroupController {
     }
 
     @PutMapping("/{groupId}")
-    public ApiSuccessResponse<GroupPostResponse> updateGroup(@Login LoginMember loginMember,
+    public ApiSuccessResponse<GroupPostResponse> updateGroup(@Login UserToken userToken,
                                          @PathVariable long groupId,
                                          @RequestBody GroupPutRequest request) {
-        return ApiSuccessResponse.of(groupService.updateGroup(loginMember, groupId, request));
+        return ApiSuccessResponse.of(groupService.updateGroup(userToken, groupId, request));
     }
 
 

--- a/chaekit-spring/src/main/java/qwerty/chaekit/controller/highlight/HighlightController.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/controller/highlight/HighlightController.java
@@ -8,7 +8,7 @@ import qwerty.chaekit.dto.highlight.*;
 import qwerty.chaekit.dto.page.PageResponse;
 import qwerty.chaekit.global.response.ApiSuccessResponse;
 import qwerty.chaekit.global.security.resolver.Login;
-import qwerty.chaekit.global.security.resolver.LoginMember;
+import qwerty.chaekit.global.security.resolver.UserToken;
 import qwerty.chaekit.service.highlight.HighlightService;
 
 @RestController
@@ -18,23 +18,23 @@ public class HighlightController {
     private final HighlightService highlightService;
 
     @GetMapping
-    public ApiSuccessResponse<PageResponse<HighlightFetchResponse>> getHighlights(@Login LoginMember loginMember,
+    public ApiSuccessResponse<PageResponse<HighlightFetchResponse>> getHighlights(@Login UserToken userToken,
                                                                                   @ParameterObject Pageable pageable,
                                                                                   @RequestParam(required = false) Long activityId,
                                                                                   @RequestParam(required = false) Long bookId,
                                                                                   @RequestParam(required = false) String spine,
                                                                                   @RequestParam(required = false) Boolean me
     ) {
-        return ApiSuccessResponse.of(highlightService.fetchHighlights(loginMember, pageable, activityId, bookId, spine, me));
+        return ApiSuccessResponse.of(highlightService.fetchHighlights(userToken, pageable, activityId, bookId, spine, me));
     }
 
     @PostMapping
-    public ApiSuccessResponse<HighlightPostResponse> createHighlight(@Login LoginMember loginMember, @RequestBody HighlightPostRequest request) {
-        return ApiSuccessResponse.of(highlightService.createHighlight(loginMember, request));
+    public ApiSuccessResponse<HighlightPostResponse> createHighlight(@Login UserToken userToken, @RequestBody HighlightPostRequest request) {
+        return ApiSuccessResponse.of(highlightService.createHighlight(userToken, request));
     }
 
     @PutMapping("/{id}")
-    public ApiSuccessResponse<HighlightPostResponse> updateHighlight(@Login LoginMember loginMember, @PathVariable Long id, @RequestBody HighlightPutRequest request) {
-        return ApiSuccessResponse.of(highlightService.updateHighlight(loginMember, id, request));
+    public ApiSuccessResponse<HighlightPostResponse> updateHighlight(@Login UserToken userToken, @PathVariable Long id, @RequestBody HighlightPutRequest request) {
+        return ApiSuccessResponse.of(highlightService.updateHighlight(userToken, id, request));
     }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/controller/member/admin/AdminController.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/controller/member/admin/AdminController.java
@@ -29,9 +29,9 @@ public class AdminController {
         return ApiSuccessResponse.of(adminService.getNotAcceptedPublishers(pageable));
     }
 
-    @PostMapping("/publishers/{id}/accept")
-    public ApiSuccessResponse<Boolean> acceptPublisher(@PathVariable Long id) {
-        return ApiSuccessResponse.of(adminService.acceptPublisher(id));
+    @PostMapping("/publishers/{publisherId}/accept")
+    public ApiSuccessResponse<Boolean> acceptPublisher(@PathVariable Long publisherId) {
+        return ApiSuccessResponse.of(adminService.acceptPublisher(publisherId));
     }
 
     @PostMapping("/books/upload")

--- a/chaekit-spring/src/main/java/qwerty/chaekit/controller/member/admin/AdminController.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/controller/member/admin/AdminController.java
@@ -4,15 +4,13 @@ import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
-import qwerty.chaekit.dto.member.PublisherInfoResponse;
-import qwerty.chaekit.dto.ebook.EbookFetchResponse;
-import qwerty.chaekit.dto.page.PageResponse;
 import qwerty.chaekit.dto.ebook.upload.EbookDownloadResponse;
 import qwerty.chaekit.dto.ebook.upload.EbookUploadRequest;
+import qwerty.chaekit.dto.member.PublisherInfoResponse;
+import qwerty.chaekit.dto.page.PageResponse;
 import qwerty.chaekit.global.response.ApiSuccessResponse;
-import qwerty.chaekit.service.member.admin.AdminService;
 import qwerty.chaekit.service.ebook.EbookFileService;
-import qwerty.chaekit.service.ebook.EbookService;
+import qwerty.chaekit.service.member.admin.AdminService;
 
 import java.io.IOException;
 
@@ -22,7 +20,6 @@ import java.io.IOException;
 public class AdminController {
     private final AdminService adminService;
     private final EbookFileService ebookFileService;
-    private final EbookService ebookService;
 
     @GetMapping("/publishers/pending")
     public ApiSuccessResponse<PageResponse<PublisherInfoResponse>> fetchPendingList(@ParameterObject Pageable pageable) {
@@ -42,10 +39,5 @@ public class AdminController {
     @GetMapping("/books/{ebookId}")
     public ApiSuccessResponse<EbookDownloadResponse> downloadFile(@PathVariable Long ebookId) {
         return ApiSuccessResponse.of(ebookFileService.getPresignedEbookUrl(ebookId));
-    }
-
-    @GetMapping("/books")
-    public ApiSuccessResponse<PageResponse<EbookFetchResponse>> getBooks(@ParameterObject Pageable pageable) {
-        return ApiSuccessResponse.of(ebookService.fetchEbookList(pageable));
     }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/controller/member/publisher/PublisherController.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/controller/member/publisher/PublisherController.java
@@ -8,7 +8,7 @@ import qwerty.chaekit.dto.member.PublisherJoinResponse;
 import qwerty.chaekit.dto.member.PublisherMemberResponse;
 import qwerty.chaekit.global.response.ApiSuccessResponse;
 import qwerty.chaekit.global.security.resolver.Login;
-import qwerty.chaekit.global.security.resolver.LoginMember;
+import qwerty.chaekit.global.security.resolver.UserToken;
 import qwerty.chaekit.service.member.publisher.PublisherJoinService;
 import qwerty.chaekit.service.member.publisher.PublisherService;
 
@@ -20,8 +20,8 @@ public class PublisherController {
     private final PublisherService publisherService;
 
     @GetMapping("/me")
-    public ApiSuccessResponse<PublisherMemberResponse> publisherInfo(@Login LoginMember loginMember) {
-        return ApiSuccessResponse.of(publisherService.getPublisherProfile(loginMember));
+    public ApiSuccessResponse<PublisherMemberResponse> publisherInfo(@Login UserToken userToken) {
+        return ApiSuccessResponse.of(publisherService.getPublisherProfile(userToken));
     }
 
     @PostMapping("/join")

--- a/chaekit-spring/src/main/java/qwerty/chaekit/controller/member/publisher/PublisherController.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/controller/member/publisher/PublisherController.java
@@ -1,31 +1,32 @@
 package qwerty.chaekit.controller.member.publisher;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import qwerty.chaekit.dto.member.PublisherJoinRequest;
 import qwerty.chaekit.dto.member.PublisherJoinResponse;
 import qwerty.chaekit.dto.member.PublisherMemberResponse;
 import qwerty.chaekit.global.response.ApiSuccessResponse;
 import qwerty.chaekit.global.security.resolver.Login;
-import qwerty.chaekit.global.security.resolver.UserToken;
+import qwerty.chaekit.global.security.resolver.PublisherToken;
 import qwerty.chaekit.service.member.publisher.PublisherJoinService;
 import qwerty.chaekit.service.member.publisher.PublisherService;
 
 @RestController
 @RequestMapping("/api/publishers")
 @RequiredArgsConstructor
+@Slf4j
 public class PublisherController {
     private final PublisherJoinService joinService;
     private final PublisherService publisherService;
 
     @GetMapping("/me")
-    public ApiSuccessResponse<PublisherMemberResponse> publisherInfo(@Login UserToken userToken) {
-        return ApiSuccessResponse.of(publisherService.getPublisherProfile(userToken));
+    public ApiSuccessResponse<PublisherMemberResponse> userInfo(@Login PublisherToken token) {
+        return ApiSuccessResponse.of(publisherService.getPublisherProfile(token));
     }
 
     @PostMapping("/join")
-    public ApiSuccessResponse<PublisherJoinResponse> publisherJoin(@RequestBody @Valid PublisherJoinRequest joinRequest) {
+    public ApiSuccessResponse<PublisherJoinResponse> publisherJoin(@RequestBody PublisherJoinRequest joinRequest) {
         return ApiSuccessResponse.of(joinService.join(joinRequest));
     }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/controller/member/user/UserController.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/controller/member/user/UserController.java
@@ -9,7 +9,7 @@ import qwerty.chaekit.dto.member.UserJoinResponse;
 import qwerty.chaekit.dto.member.UserMemberResponse;
 import qwerty.chaekit.global.response.ApiSuccessResponse;
 import qwerty.chaekit.global.security.resolver.Login;
-import qwerty.chaekit.global.security.resolver.LoginMember;
+import qwerty.chaekit.global.security.resolver.UserToken;
 import qwerty.chaekit.service.member.user.UserJoinService;
 import qwerty.chaekit.service.member.user.UserService;
 
@@ -22,8 +22,8 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/me")
-    public ApiSuccessResponse<UserMemberResponse> userInfo(@Login LoginMember loginMember) {
-        return ApiSuccessResponse.of(userService.getUserProfile(loginMember));
+    public ApiSuccessResponse<UserMemberResponse> userInfo(@Login UserToken userToken) {
+        return ApiSuccessResponse.of(userService.getUserProfile(userToken));
     }
 
     @PostMapping("/join")

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/GroupMember.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/GroupMember.java
@@ -22,11 +22,11 @@ public class GroupMember {
 
     @ManyToOne
     @JoinColumn(name ="user_id", nullable = false)
-    private UserProfile userProfile;
+    private UserProfile user;
 
     @Builder
-    public GroupMember(ReadingGroup readingGroup, UserProfile userProfile) {
+    public GroupMember(ReadingGroup readingGroup, UserProfile user) {
         this.readingGroup = readingGroup;
-        this.userProfile = userProfile;
+        this.user = user;
     }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/ReadingGroup.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/ReadingGroup.java
@@ -47,16 +47,16 @@ public class ReadingGroup extends BaseEntity {
     }
 
     public List<UserProfile> getMembers() {
-        return groupMembers.stream().map(GroupMember::getUserProfile).toList();
+        return groupMembers.stream().map(GroupMember::getUser).toList();
     }
 
-    public void addMember(UserProfile userProfile) {
-        GroupMember groupMember = new GroupMember(this, userProfile);
+    public void addMember(UserProfile user) {
+        GroupMember groupMember = new GroupMember(this, user);
         groupMembers.add(groupMember);
     }
 
-    public void removeMember(UserProfile userProfile) {
-        groupMembers.removeIf(member -> member.getUserProfile().equals(userProfile));
+    public void removeMember(UserProfile user) {
+        groupMembers.removeIf(member -> member.getUser().equals(user));
     }
 
     public void updateDescription(String description) {

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/ActivityMember.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/ActivityMember.java
@@ -2,13 +2,16 @@ package qwerty.chaekit.domain.group.activity;
 
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import qwerty.chaekit.domain.BaseEntity;
 import qwerty.chaekit.domain.member.user.UserProfile;
 
 @Entity
 @Getter
 @Table(name = "activity_member")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ActivityMember extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/DiscussionComment.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/DiscussionComment.java
@@ -2,13 +2,16 @@ package qwerty.chaekit.domain.group.activity.discussion;
 
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import qwerty.chaekit.domain.BaseEntity;
 import qwerty.chaekit.domain.member.user.UserProfile;
 
 @Entity
 @Getter
 @Table(name = "discussion_comment")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DiscussionComment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/highlight/repository/HighlightRepository.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/highlight/repository/HighlightRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 public interface HighlightRepository {
     Optional<Highlight> findById(Long id);
     Highlight save(Highlight highlight);
-    Page<Highlight> findHighlights(Pageable pageable, Long memberId, Long activityId, Long bookId, String spine, Boolean me);
+    Page<Highlight> findHighlights(Pageable pageable, Long userId, Long activityId, Long bookId, String spine, Boolean me);
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/highlight/repository/HighlightRepositoryImpl.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/highlight/repository/HighlightRepositoryImpl.java
@@ -32,7 +32,7 @@ public class HighlightRepositoryImpl implements HighlightRepository {
     }
 
     @Override
-    public Page<Highlight> findHighlights(Pageable pageable, Long memberId, Long activityId, Long bookId, String spine, Boolean me) {
+    public Page<Highlight> findHighlights(Pageable pageable, Long userId, Long activityId, Long bookId, String spine, Boolean me) {
         QHighlight highlight = QHighlight.highlight;
         BooleanBuilder where = new BooleanBuilder();
 
@@ -49,7 +49,7 @@ public class HighlightRepositoryImpl implements HighlightRepository {
             where.and(highlight.spine.eq(spine));
         }
         if (me == null || me) {
-            where.and(highlight.author.member.id.eq(memberId));
+            where.and(highlight.author.id.eq(userId));
         } else {
             // TODO: activityId에 현재 자신이 속해 있는 경우만 가능
             throw new IllegalStateException("Not Implemented Yet");

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/member/user/UserProfileRepository.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/member/user/UserProfileRepository.java
@@ -5,4 +5,6 @@ import java.util.Optional;
 public interface UserProfileRepository  extends JpaRepository<UserProfile,Long> {
     Optional<UserProfile> findByMember_Id(Long id);
     boolean existsByNickname(String nickname);
+
+    Optional<UserProfile> findByMember_Username(String username);
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/LoginResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/LoginResponse.java
@@ -5,7 +5,8 @@ import lombok.Builder;
 @Builder
 public record LoginResponse(
         Long id,
-        Long profileId,
+        Long userId,
+        Long publisherId,
         String role,
         String accessToken
 ){ }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/LoginResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/LoginResponse.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 @Builder
 public record LoginResponse(
         Long id,
+        Long profileId,
         String role,
         String accessToken
 ){ }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/PublisherInfoResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/PublisherInfoResponse.java
@@ -8,16 +8,16 @@ import java.time.LocalDateTime;
 @Builder
 public record PublisherInfoResponse(
         Long id,
-        Long profileId,
+        Long publisherId,
         String publisherName,
         LocalDateTime createdAt
 ) {
-    public static PublisherInfoResponse of(PublisherProfile profile) {
+    public static PublisherInfoResponse of(PublisherProfile publisher) {
         return PublisherInfoResponse.builder()
-                .id(profile.getMember().getId())
-                .profileId(profile.getId())
-                .publisherName(profile.getPublisherName())
-                .createdAt(profile.getCreatedAt())
+                .id(publisher.getMember().getId())
+                .publisherId(publisher.getId())
+                .publisherName(publisher.getPublisherName())
+                .createdAt(publisher.getCreatedAt())
                 .build();
     }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/PublisherInfoResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/PublisherInfoResponse.java
@@ -8,12 +8,14 @@ import java.time.LocalDateTime;
 @Builder
 public record PublisherInfoResponse(
         Long id,
+        Long profileId,
         String publisherName,
         LocalDateTime createdAt
 ) {
     public static PublisherInfoResponse of(PublisherProfile profile) {
         return PublisherInfoResponse.builder()
                 .id(profile.getMember().getId())
+                .profileId(profile.getId())
                 .publisherName(profile.getPublisherName())
                 .createdAt(profile.getCreatedAt())
                 .build();

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/PublisherJoinResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/PublisherJoinResponse.java
@@ -9,6 +9,5 @@ public record PublisherJoinResponse(
         String accessToken,
         String publisherName,
         String username,
-        String role,
         Boolean isAccepted
 ){ }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/PublisherJoinResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/PublisherJoinResponse.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 @Builder
 public record PublisherJoinResponse(
         Long id,
+        Long profileId,
         String accessToken,
         String publisherName,
         String username,

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/PublisherJoinResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/PublisherJoinResponse.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 @Builder
 public record PublisherJoinResponse(
         Long id,
-        Long profileId,
+        Long publisherId,
         String accessToken,
         String publisherName,
         String username,

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/PublisherMemberResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/PublisherMemberResponse.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 @Builder
 public record PublisherMemberResponse(
         Long id,
-        Long profileId,
+        Long publisherId,
         String publisherName,
         String email,
         String role,

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/PublisherMemberResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/PublisherMemberResponse.java
@@ -7,7 +7,7 @@ public record PublisherMemberResponse(
         Long id,
         Long profileId,
         String publisherName,
-        String username,
+        String email,
         String role,
         Boolean isAccepted
 ){ }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/PublisherMemberResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/PublisherMemberResponse.java
@@ -8,6 +8,5 @@ public record PublisherMemberResponse(
         Long publisherId,
         String publisherName,
         String email,
-        String role,
         Boolean isAccepted
 ){ }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/PublisherMemberResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/PublisherMemberResponse.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 @Builder
 public record PublisherMemberResponse(
         Long id,
+        Long profileId,
         String publisherName,
         String username,
         String role,

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/UserJoinResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/UserJoinResponse.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 @Builder
 public record UserJoinResponse(
         Long id,
-        Long profileId,
+        Long userId,
         String accessToken,
         String nickname,
         String username,

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/UserJoinResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/UserJoinResponse.java
@@ -8,6 +8,5 @@ public record UserJoinResponse(
         Long userId,
         String accessToken,
         String nickname,
-        String username,
-        String role
+        String username
 ){ }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/UserJoinResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/UserJoinResponse.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 @Builder
 public record UserJoinResponse(
         Long id,
+        Long profileId,
         String accessToken,
         String nickname,
         String username,

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/UserMemberResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/UserMemberResponse.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 @Builder
 public record UserMemberResponse(
         Long id,
-        Long profileId,
+        Long userId,
         String username,
         String nickname,
         String role

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/UserMemberResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/UserMemberResponse.java
@@ -7,6 +7,5 @@ public record UserMemberResponse(
         Long id,
         Long userId,
         String username,
-        String nickname,
-        String role
+        String nickname
 ){ }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/UserMemberResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/member/UserMemberResponse.java
@@ -5,7 +5,8 @@ import lombok.Builder;
 @Builder
 public record UserMemberResponse(
         Long id,
-        String nickname,
+        Long profileId,
         String username,
+        String nickname,
         String role
 ){ }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/enums/ErrorCode.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/enums/ErrorCode.java
@@ -36,7 +36,12 @@ public enum ErrorCode {
     GROUP_NOT_FOUND("GROUP_NOT_FOUND", "해당 독서모임이 존재하지 않습니다"),
     HIGHLIGHT_NOT_FOUND("HIGHLIGHT_NOT_FOUND", "해당 하이라이트가 존재하지 않습니다"),
     ACTIVITY_NOT_FOUND("ACTIVITY_NOT_FOUND", "해당 활동이 존재하지 않습니다"),
-    ;
+
+    // Exception Handler
+    INVALID_INPUT("INVALID_INPUT", "입력값이 유효하지 않습니다"),
+
+    METHOD_NOT_ALLOWED("METHOD_NOT_ALLOWED", "지원하지 않는 HTTP 메서드입니다."),
+    NO_RESOURCE_FOUND("NO_RESOURCE_FOUND", "존재하지 않는 경로입니다."),;
 
     private final String code;
     private final String message;

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/enums/ErrorCode.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/enums/ErrorCode.java
@@ -26,6 +26,8 @@ public enum ErrorCode {
     HIGHLIGHT_NOT_YOURS("HIGHLIGHT_NOT_YOURS", "하이라이트는 본인만 수정할 수 있습니다"),
     GROUP_LEADER_ONLY("GROUP_LEADER_ONLY", "모임지기만 사용할 수 있는 기능입니다"),
     ACTIVITY_GROUP_MISMATCH("ACTIVITY_GROUP_MISMATCH", "해당 독서모임의 활동이 아닙니다"),
+    ONLY_USER("ONLY_USER", "일반 회원만 사용할 수 있는 기능입니다"),
+    ONLY_PUBLISHER("ONLY_PUBLISHER", "출판사 회원만 사용할 수 있는 기능입니다"),
 
     // NOT_FOUND
     EBOOK_NOT_FOUND("EBOOK_NOT_FOUND", "해당 전자책이 존재하지 않습니다"),

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/exception/GlobalExceptionHandler.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
+import qwerty.chaekit.global.enums.ErrorCode;
 import qwerty.chaekit.global.response.ApiErrorResponse;
 
 import java.util.stream.Collectors;
@@ -17,6 +18,18 @@ import java.util.stream.Collectors;
 @RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
+    @ExceptionHandler(BadRequestException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ApiErrorResponse handleBadRequestException(BadRequestException ex) {
+        return ApiErrorResponse.of(ex.getErrorCode(), ex.getMessage());
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public ApiErrorResponse handleNoSuchElementException(ForbiddenException ex) {
+        return ApiErrorResponse.of(ex.getErrorCode(), ex.getMessage());
+    }
+
     @ExceptionHandler(NotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public ApiErrorResponse handleNoSuchElementException(NotFoundException ex) {
@@ -30,25 +43,21 @@ public class GlobalExceptionHandler {
         String message = ex.getBindingResult().getFieldErrors().stream()
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())
                 .collect(Collectors.joining(", "));
-        return ApiErrorResponse.of("INVALID_INPUT", message);
+        return ApiErrorResponse.of(ErrorCode.INVALID_INPUT.getCode(), message);
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
     public ApiErrorResponse handleMethodNotSupportedException() {
-        return ApiErrorResponse.of("METHOD_NOT_ALLOWED", "지원하지 않는 HTTP 메서드입니다.");
+        ErrorCode errorCode = ErrorCode.METHOD_NOT_ALLOWED;
+        return ApiErrorResponse.of(errorCode.getCode(), errorCode.getMessage());
     }
 
     @ExceptionHandler(NoResourceFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public ApiErrorResponse handleNoResourceFoundException() {
-        return ApiErrorResponse.of("NOT_FOUND", "존재하지 않는 경로입니다.");
-    }
-
-    @ExceptionHandler(BadRequestException.class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ApiErrorResponse handleBadRequestException(BadRequestException ex) {
-        return ApiErrorResponse.of(ex.getErrorCode(), ex.getMessage());
+        ErrorCode errorCode = ErrorCode.NO_RESOURCE_FOUND;
+        return ApiErrorResponse.of(errorCode.getCode(), errorCode.getMessage());
     }
 
     @ExceptionHandler(Exception.class)

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/init/AdminInitializer.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/init/AdminInitializer.java
@@ -11,6 +11,8 @@ import qwerty.chaekit.domain.member.MemberRepository;
 import qwerty.chaekit.domain.member.enums.Role;
 import qwerty.chaekit.domain.member.publisher.PublisherProfile;
 import qwerty.chaekit.domain.member.publisher.PublisherProfileRepository;
+import qwerty.chaekit.domain.member.user.UserProfile;
+import qwerty.chaekit.domain.member.user.UserProfileRepository;
 import qwerty.chaekit.global.properties.AdminProperties;
 import qwerty.chaekit.service.member.admin.AdminService;
 import qwerty.chaekit.service.member.MemberJoinHelper;
@@ -26,6 +28,7 @@ public class AdminInitializer implements ApplicationRunner {
     private final PublisherProfileRepository publisherProfileRepository;
     private final AdminService adminService;
     private final MemberRepository memberRepository;
+    private final UserProfileRepository userProfileRepository;
 
 
     @Override
@@ -47,15 +50,24 @@ public class AdminInitializer implements ApplicationRunner {
         } else {
             // 이미 관리자가 존재할 때
             Member admin = existingAdmin.get();
-            Optional<PublisherProfile> existingProfile = publisherProfileRepository.findByMember_Username(adminUsername);
+            Optional<PublisherProfile> publisher = publisherProfileRepository.findByMember_Username(adminUsername);
 
-            PublisherProfile adminPublisher = existingProfile.orElseGet(() -> {
+            PublisherProfile adminPublisher = publisher.orElseGet(() -> {
                 PublisherProfile newProfile = publisherProfileRepository.save(new PublisherProfile(admin, adminUsername));
                 log.info("관리자 출판사 프로필이 존재하지 않아 추가되었습니다.");
                 return newProfile;
             });
 
+            Optional<UserProfile> user = userProfileRepository.findByMember_Username(adminUsername);
+
+            UserProfile adminUser = user.orElseGet(() -> {
+                UserProfile newProfile = userProfileRepository.save(new UserProfile(admin, adminUsername));
+                log.info("관리자 사용자 프로필이 존재하지 않아 추가되었습니다.");
+                return newProfile;
+            });
+
             adminService.setAdminPublisherId(adminPublisher.getId());
+            adminService.setAdminUserId(adminUser.getId());
             log.info("관리자가 이미 존재합니다. memberId = {}", admin.getId());
         }
     }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/jwt/JwtUtil.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/jwt/JwtUtil.java
@@ -32,8 +32,12 @@ public class JwtUtil {
         return claims.get("memberId", Long.class);
     }
 
-    public Long getProfileId(Claims claims) {
+    public Long getUserId(Claims claims) {
         return claims.get("userId", Long.class);
+    }
+
+    public Long getPublisherId(Claims claims) {
+        return claims.get("publisherId", Long.class);
     }
 
     public String getEmail(Claims claims) {
@@ -61,11 +65,12 @@ public class JwtUtil {
         }
     }
 
-    public String createJwt(Long memberId, Long profileId, String email, String role) {
+    public String createJwt(Long memberId, Long userId, Long publisherId, String email, String role) {
 
         return Jwts.builder()
                 .claim("memberId", memberId)
-                .claim("userId", profileId)
+                .claim("userId", userId)
+                .claim("publisherId", publisherId)
                 .claim("email", email)
                 .claim("role", role)
                 .issuedAt(new Date(System.currentTimeMillis()))

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/jwt/JwtUtil.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/jwt/JwtUtil.java
@@ -33,7 +33,7 @@ public class JwtUtil {
     }
 
     public Long getProfileId(Claims claims) {
-        return claims.get("profileId", Long.class);
+        return claims.get("userId", Long.class);
     }
 
     public String getEmail(Claims claims) {
@@ -65,7 +65,7 @@ public class JwtUtil {
 
         return Jwts.builder()
                 .claim("memberId", memberId)
-                .claim("profileId", profileId)
+                .claim("userId", profileId)
                 .claim("email", email)
                 .claim("role", role)
                 .issuedAt(new Date(System.currentTimeMillis()))

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/jwt/JwtUtil.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/jwt/JwtUtil.java
@@ -32,8 +32,12 @@ public class JwtUtil {
         return claims.get("memberId", Long.class);
     }
 
-    public String getUsername(Claims claims) {
-        return claims.get("username", String.class);
+    public Long getProfileId(Claims claims) {
+        return claims.get("profileId", Long.class);
+    }
+
+    public String getEmail(Claims claims) {
+        return claims.get("email", String.class);
     }
 
     public String getRole(Claims claims) {
@@ -57,11 +61,12 @@ public class JwtUtil {
         }
     }
 
-    public String createJwt(Long memberId, String username, String role) {
+    public String createJwt(Long memberId, Long profileId, String email, String role) {
 
         return Jwts.builder()
                 .claim("memberId", memberId)
-                .claim("username", username)
+                .claim("profileId", profileId)
+                .claim("email", email)
                 .claim("role", role)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + jwtProperties.expirationMs()))

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/response/advice/ApiResponseWrapperAdvice.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/response/advice/ApiResponseWrapperAdvice.java
@@ -8,7 +8,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 import qwerty.chaekit.global.response.ApiErrorResponse;
 import qwerty.chaekit.global.response.ApiSuccessResponse;

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/response/advice/ApiResponseWrapperAdvice.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/response/advice/ApiResponseWrapperAdvice.java
@@ -22,7 +22,7 @@ import qwerty.chaekit.global.response.ApiSuccessResponse;
  * {
  *   "isSuccessful": true,
  *   "data": {
- *     "username": "testuser",
+ *     "email": "testuser",
  *     "nickname": "테스트 유저"
  *   }
  * }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/config/SecurityConfig.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/config/SecurityConfig.java
@@ -100,14 +100,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/swagger-resources/**", "/webjars/**")
                         .permitAll()
-                        .requestMatchers("/api", "/api/users/join").permitAll()
-                        .requestMatchers("/api/users/**").hasAuthority(Role.ROLE_USER.name())
-
-                        .requestMatchers("/api/publishers/join").permitAll()
-                        .requestMatchers("/api/publishers/**").hasAuthority(Role.ROLE_PUBLISHER.name())
-
                         .requestMatchers("/api/admin/**").hasAuthority(Role.ROLE_ADMIN.name())
-                        .anyRequest().authenticated()
+                        .anyRequest().permitAll()
         );
 
         http

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/filter/JwtFilter.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/filter/JwtFilter.java
@@ -42,11 +42,12 @@ public class JwtFilter extends OncePerRequestFilter {
 
         Claims parsedJwt = jwtUtil.parseJwt(token);
         Long memberId = jwtUtil.getMemberId(parsedJwt);
-        Long profileId = jwtUtil.getProfileId(parsedJwt);
+        Long userId = jwtUtil.getUserId(parsedJwt);
+        Long publisherId = jwtUtil.getPublisherId(parsedJwt);
         String email = jwtUtil.getEmail(parsedJwt);
         String role = jwtUtil.getRole(parsedJwt);
 
-        CustomUserDetails customUserDetails = new CustomUserDetails(memberId, profileId, email, role);
+        CustomUserDetails customUserDetails = new CustomUserDetails(memberId, userId, publisherId, email, null, role);
 
         Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
 

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/filter/JwtFilter.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/filter/JwtFilter.java
@@ -5,14 +5,15 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
-import qwerty.chaekit.global.security.model.CustomUserDetails;
 import qwerty.chaekit.global.jwt.JwtUtil;
+import qwerty.chaekit.global.security.model.CustomUserDetails;
 
 import java.io.IOException;
 
@@ -22,7 +23,7 @@ public class JwtFilter extends OncePerRequestFilter {
     private final JwtUtil jwtUtil;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain) throws ServletException, IOException {
         //request에서 Authorization 헤더를 찾음
         String authorization= request.getHeader("Authorization");
 

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/filter/JwtFilter.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/filter/JwtFilter.java
@@ -29,7 +29,6 @@ public class JwtFilter extends OncePerRequestFilter {
 
         //Authorization 헤더 검증
         if (authorization == null || !authorization.startsWith("Bearer ")) {
-            log.info("No token");
             filterChain.doFilter(request, response);
             return;
         }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/filter/JwtFilter.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/filter/JwtFilter.java
@@ -42,10 +42,11 @@ public class JwtFilter extends OncePerRequestFilter {
 
         Claims parsedJwt = jwtUtil.parseJwt(token);
         Long memberId = jwtUtil.getMemberId(parsedJwt);
-        String username = jwtUtil.getUsername(parsedJwt);
+        Long profileId = jwtUtil.getProfileId(parsedJwt);
+        String email = jwtUtil.getEmail(parsedJwt);
         String role = jwtUtil.getRole(parsedJwt);
 
-        CustomUserDetails customUserDetails = new CustomUserDetails(memberId, username, role);
+        CustomUserDetails customUserDetails = new CustomUserDetails(memberId, profileId, email, role);
 
         Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
 

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/filter/login/LoginFilter.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/filter/login/LoginFilter.java
@@ -57,21 +57,23 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
         Long memberId = customUserDetails.getMemberId();
-        String username = customUserDetails.getUsername();
+        Long profileId = customUserDetails.getProfileId();
+        String email = customUserDetails.getEmail();
 
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
         authorities.stream().findFirst().map(GrantedAuthority::getAuthority).ifPresentOrElse(
                 (role)-> {
-                    String token = jwtUtil.createJwt(memberId, username, role);
-                    sendSuccessResponse(response, token, memberId, role);
+                    String token = jwtUtil.createJwt(memberId, profileId, email, role);
+                    sendSuccessResponse(response, token, memberId, profileId, role);
                 }, ()-> responseSender.sendError(response, 500, "INVALID_ROLE", "권한 정보가 존재하지 않습니다.")
         );
     }
 
-    private void sendSuccessResponse(HttpServletResponse response, String token, Long memberId, String role) {
+    private void sendSuccessResponse(HttpServletResponse response, String token, Long memberId, Long profileId, String role) {
         LoginResponse loginResponse = LoginResponse.builder()
                 .accessToken("Bearer " + token)
                 .id(memberId)
+                .profileId(profileId)
                 .role(role)
                 .build();
         responseSender.sendSuccess(response, loginResponse);

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/filter/login/LoginFilter.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/filter/login/LoginFilter.java
@@ -57,23 +57,25 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
         Long memberId = customUserDetails.getMemberId();
-        Long profileId = customUserDetails.getProfileId();
+        Long userId = customUserDetails.getUserId();
+        Long publisherId = customUserDetails.getPublisherId();
         String email = customUserDetails.getEmail();
 
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
         authorities.stream().findFirst().map(GrantedAuthority::getAuthority).ifPresentOrElse(
                 (role)-> {
-                    String token = jwtUtil.createJwt(memberId, profileId, email, role);
-                    sendSuccessResponse(response, token, memberId, profileId, role);
+                    String token = jwtUtil.createJwt(memberId, userId, publisherId, email, role);
+                    sendSuccessResponse(response, token, memberId, userId, publisherId, role);
                 }, ()-> responseSender.sendError(response, 500, "INVALID_ROLE", "권한 정보가 존재하지 않습니다.")
         );
     }
 
-    private void sendSuccessResponse(HttpServletResponse response, String token, Long memberId, Long profileId, String role) {
+    private void sendSuccessResponse(HttpServletResponse response, String token, Long memberId, Long userId, Long publisherId, String role) {
         LoginResponse loginResponse = LoginResponse.builder()
                 .accessToken("Bearer " + token)
                 .id(memberId)
-                .profileId(profileId)
+                .userId(userId)
+                .publisherId(publisherId)
                 .role(role)
                 .build();
         responseSender.sendSuccess(response, loginResponse);

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/model/CustomUserDetails.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/model/CustomUserDetails.java
@@ -13,23 +13,18 @@ public class CustomUserDetails implements UserDetails {
     @Getter
     private final Long memberId;
     @Getter
-    private final Long profileId;
+    private final Long userId;
+    @Getter
+    private final Long publisherId;
     @Getter
     private final String email;
     private final String password;
     private final String role;
 
-    public CustomUserDetails(Long memberId, Long profileId, String username, String role) {
+    public CustomUserDetails(Long memberId, Long userId, Long publisherId, String username, String password, String role) {
         this.memberId = memberId;
-        this.profileId = profileId;
-        this.email = username;
-        this.password = null;
-        this.role = role;
-    }
-
-    public CustomUserDetails(Long memberId, Long profileId, String username, String password, String role) {
-        this.memberId = memberId;
-        this.profileId = profileId;
+        this.userId = userId;
+        this.publisherId = publisherId;
         this.email = username;
         this.password = password;
         this.role = role;

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/model/CustomUserDetails.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/model/CustomUserDetails.java
@@ -7,23 +7,29 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.ArrayList;
 import java.util.Collection;
 
+// 1. JWT를 읽을 때 사용
+// 2. AuthenticationManager에서 로그인할 때 사용
 public class CustomUserDetails implements UserDetails {
     @Getter
     private final Long memberId;
-    private final String username;
+    @Getter
+    private final Long profileId;
+    private final String email;
     private final String password;
     private final String role;
 
-    public CustomUserDetails(Long memberId, String username, String role) {
+    public CustomUserDetails(Long memberId, Long profileId, String username, String role) {
         this.memberId = memberId;
-        this.username = username;
+        this.profileId = profileId;
+        this.email = username;
         this.password = null;
         this.role = role;
     }
 
-    public CustomUserDetails(Long memberId, String username, String password, String role) {
+    public CustomUserDetails(Long memberId, Long profileId, String username, String password, String role) {
         this.memberId = memberId;
-        this.username = username;
+        this.profileId = profileId;
+        this.email = username;
         this.password = password;
         this.role = role;
     }
@@ -42,7 +48,11 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return username;
+        return email;
+    }
+
+    public String getEmail() {
+        return email;
     }
 
     @Override

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/model/CustomUserDetails.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/model/CustomUserDetails.java
@@ -14,6 +14,7 @@ public class CustomUserDetails implements UserDetails {
     private final Long memberId;
     @Getter
     private final Long profileId;
+    @Getter
     private final String email;
     private final String password;
     private final String role;
@@ -48,10 +49,6 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return email;
-    }
-
-    public String getEmail() {
         return email;
     }
 

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/resolver/LoginArgumentResolver.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/resolver/LoginArgumentResolver.java
@@ -1,5 +1,6 @@
 package qwerty.chaekit.global.security.resolver;
 
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
@@ -23,8 +24,8 @@ public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
     }
 
     @Override
-    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
-                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+    public Object resolveArgument(@NonNull MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  @NonNull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth == null || !auth.isAuthenticated()) {
             throw new ForbiddenException(ErrorCode.NO_VALID_TOKEN);

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/resolver/LoginArgumentResolver.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/resolver/LoginArgumentResolver.java
@@ -2,8 +2,10 @@ package qwerty.chaekit.global.security.resolver;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -15,6 +17,9 @@ import qwerty.chaekit.global.enums.ErrorCode;
 import qwerty.chaekit.global.exception.ForbiddenException;
 import qwerty.chaekit.global.security.model.CustomUserDetails;
 
+import java.util.Collection;
+
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
@@ -30,37 +35,55 @@ public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
     @Override
     public Object resolveArgument(@NonNull MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   @NonNull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth == null || !auth.isAuthenticated()) {
-            throw new ForbiddenException(ErrorCode.NO_VALID_TOKEN);
-        }
-        if (!(auth.getPrincipal() instanceof CustomUserDetails userDetails)) {
-            throw new IllegalStateException("Invalid authentication principal");
+        // @Login 어노테이션이 붙은 파라미터의 타입에 따라 requiredRole을 설정
+        final Role requiredRole;
+        if(parameter.getParameterType().equals(UserToken.class)) {
+            requiredRole = Role.ROLE_USER;
+        } else if (parameter.getParameterType().equals(PublisherToken.class)) {
+            requiredRole = Role.ROLE_PUBLISHER;
+        } else {
+            throw new IllegalArgumentException("Unsupported parameter type: " + parameter.getParameterType());
         }
 
-        String role = userDetails.getAuthorities().iterator().next().getAuthority();
-        if (parameter.getParameterType().equals(UserToken.class)) {
-            if (!role.equals(Role.ROLE_USER.name()) && !role.equals(Role.ROLE_ADMIN.name())) {
+        // CustomUserDetails를 SecurityContext에서 가져옴
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+            throw new IllegalStateException("SecurityContext에 인증 정보가 없습니다.");
+        }
+        if (!(auth.getPrincipal() instanceof CustomUserDetails userDetails)) { // if annonymous user
+            if(requiredRole == Role.ROLE_USER) {
+                throw new ForbiddenException(ErrorCode.ONLY_USER);
+            } else { // if (requiredRole == Role.ROLE_PUBLISHER)
+                throw new ForbiddenException(ErrorCode.ONLY_PUBLISHER);
+            }
+        }
+
+        Collection<? extends GrantedAuthority> authorities = userDetails.getAuthorities();
+        if (authorities == null || authorities.isEmpty()) {
+            throw new IllegalStateException("사용자 권한이 존재하지 않습니다.");
+        }
+        String loginRole = authorities.iterator().next().getAuthority();
+
+        if (requiredRole == Role.ROLE_USER) {
+            if (!loginRole.equals(Role.ROLE_USER.name()) && !loginRole.equals(Role.ROLE_ADMIN.name())) {
                 throw new ForbiddenException(ErrorCode.ONLY_USER);
             }
             return UserToken.builder()
                     .memberId(userDetails.getMemberId())
                     .userId(userDetails.getProfileId())
                     .email(userDetails.getEmail())
-                    .role(role)
+                    .role(loginRole)
                     .build();
-        } else if (parameter.getParameterType().equals(PublisherToken.class)) {
-            if (!role.equals(Role.ROLE_PUBLISHER.name()) && !role.equals(Role.ROLE_ADMIN.name())) {
+        } else { // if (requiredRole == Role.ROLE_PUBLISHER)
+            if (!loginRole.equals(Role.ROLE_PUBLISHER.name()) && !loginRole.equals(Role.ROLE_ADMIN.name())) {
                 throw new ForbiddenException(ErrorCode.ONLY_PUBLISHER);
             }
             return PublisherToken.builder()
                     .memberId(userDetails.getMemberId())
                     .publisherId(userDetails.getProfileId())
                     .email(userDetails.getEmail())
-                    .role(role)
+                    .role(loginRole)
                     .build();
         }
-
-        throw new IllegalArgumentException("Unsupported parameter type: " + parameter.getParameterType());
     }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/resolver/LoginArgumentResolver.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/resolver/LoginArgumentResolver.java
@@ -70,7 +70,7 @@ public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
             }
             return UserToken.builder()
                     .memberId(userDetails.getMemberId())
-                    .userId(userDetails.getProfileId())
+                    .userId(userDetails.getUserId())
                     .email(userDetails.getEmail())
                     .role(loginRole)
                     .build();
@@ -80,7 +80,7 @@ public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
             }
             return PublisherToken.builder()
                     .memberId(userDetails.getMemberId())
-                    .publisherId(userDetails.getProfileId())
+                    .publisherId(userDetails.getPublisherId())
                     .email(userDetails.getEmail())
                     .role(loginRole)
                     .build();

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/resolver/LoginArgumentResolver.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/resolver/LoginArgumentResolver.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -16,8 +15,6 @@ import qwerty.chaekit.domain.member.enums.Role;
 import qwerty.chaekit.global.enums.ErrorCode;
 import qwerty.chaekit.global.exception.ForbiddenException;
 import qwerty.chaekit.global.security.model.CustomUserDetails;
-
-import java.util.Collection;
 
 @Slf4j
 @Component
@@ -58,31 +55,23 @@ public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
             }
         }
 
-        Collection<? extends GrantedAuthority> authorities = userDetails.getAuthorities();
-        if (authorities == null || authorities.isEmpty()) {
-            throw new IllegalStateException("사용자 권한이 존재하지 않습니다.");
-        }
-        String loginRole = authorities.iterator().next().getAuthority();
-
         if (requiredRole == Role.ROLE_USER) {
-            if (!loginRole.equals(Role.ROLE_USER.name()) && !loginRole.equals(Role.ROLE_ADMIN.name())) {
+            if (userDetails.getUserId() == null) {
                 throw new ForbiddenException(ErrorCode.ONLY_USER);
             }
             return UserToken.builder()
                     .memberId(userDetails.getMemberId())
                     .userId(userDetails.getUserId())
                     .email(userDetails.getEmail())
-                    .role(loginRole)
                     .build();
         } else { // if (requiredRole == Role.ROLE_PUBLISHER)
-            if (!loginRole.equals(Role.ROLE_PUBLISHER.name()) && !loginRole.equals(Role.ROLE_ADMIN.name())) {
+            if (userDetails.getPublisherId() == null) {
                 throw new ForbiddenException(ErrorCode.ONLY_PUBLISHER);
             }
             return PublisherToken.builder()
                     .memberId(userDetails.getMemberId())
                     .publisherId(userDetails.getPublisherId())
                     .email(userDetails.getEmail())
-                    .role(loginRole)
                     .build();
         }
     }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/resolver/LoginArgumentResolver.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/resolver/LoginArgumentResolver.java
@@ -35,7 +35,8 @@ public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
 
         return LoginMember.builder()
                 .memberId(userDetails.getMemberId())
-                .username(userDetails.getUsername())
+                .profileId(userDetails.getProfileId())
+                .email(userDetails.getEmail())
                 .role(userDetails.getAuthorities().iterator().next().getAuthority())
                 .build();
     }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/resolver/LoginMember.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/resolver/LoginMember.java
@@ -5,7 +5,8 @@ import lombok.Builder;
 @Builder
 public record LoginMember(
         Long memberId,
-        String username,
+        Long profileId,
+        String email,
         String role
 ) {
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/resolver/PublisherToken.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/resolver/PublisherToken.java
@@ -3,9 +3,9 @@ package qwerty.chaekit.global.security.resolver;
 import lombok.Builder;
 
 @Builder
-public record LoginMember(
+public record PublisherToken(
         Long memberId,
-        Long profileId,
+        Long publisherId,
         String email,
         String role
 ) {

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/resolver/PublisherToken.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/resolver/PublisherToken.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 public record PublisherToken(
         Long memberId,
         Long publisherId,
-        String email,
-        String role
+        String email
 ) {
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/resolver/UserToken.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/resolver/UserToken.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 public record UserToken(
         Long memberId,
         Long userId,
-        String email,
-        String role
+        String email
 ) {
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/resolver/UserToken.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/resolver/UserToken.java
@@ -1,0 +1,12 @@
+package qwerty.chaekit.global.security.resolver;
+
+import lombok.Builder;
+
+@Builder
+public record UserToken(
+        Long memberId,
+        Long userId,
+        String email,
+        String role
+) {
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/service/CustomUserDetailsService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/service/CustomUserDetailsService.java
@@ -25,27 +25,28 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Member userData = memberRepository.findByUsername(username)
+        Member memberData = memberRepository.findByUsername(username)
                 .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 사용자입니다."));
         Long userId = null, publisherId = null;
-        if (Objects.requireNonNull(userData.getRole()) == Role.ROLE_USER) {
-            userId = userRepository.findByMember_Id(userData.getId())
+        Role role = Objects.requireNonNull(memberData.getRole());
+        if (role == Role.ROLE_USER || role == Role.ROLE_ADMIN) {
+            userId = userRepository.findByMember_Id(memberData.getId())
                     .map(UserProfile::getId)
                     .orElseThrow(() -> new UsernameNotFoundException("사용자 프로필 데이터를 찾을 수 없습니다."));
         }
-        if(Objects.requireNonNull(userData.getRole()) == Role.ROLE_PUBLISHER) {
-            publisherId = publisherRepository.findByMember_Id(userData.getId())
+        if(role == Role.ROLE_PUBLISHER || role == Role.ROLE_ADMIN) {
+            publisherId = publisherRepository.findByMember_Id(memberData.getId())
                     .map(PublisherProfile::getId)
                     .orElseThrow(() -> new UsernameNotFoundException("출판사 프로필 데이터를 찾을 수 없습니다."));
         }
 
         return new CustomUserDetails(
-                userData.getId(),
+                memberData.getId(),
                 userId,
                 publisherId,
-                userData.getUsername(),
-                userData.getPassword(),
-                userData.getRole().name()
+                memberData.getUsername(),
+                memberData.getPassword(),
+                memberData.getRole().name()
         );
     }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/service/CustomUserDetailsService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/service/CustomUserDetailsService.java
@@ -6,20 +6,37 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import qwerty.chaekit.domain.member.Member;
-import qwerty.chaekit.global.security.model.CustomUserDetails;
 import qwerty.chaekit.domain.member.MemberRepository;
+import qwerty.chaekit.domain.member.publisher.PublisherProfile;
+import qwerty.chaekit.domain.member.publisher.PublisherProfileRepository;
+import qwerty.chaekit.domain.member.user.UserProfile;
+import qwerty.chaekit.domain.member.user.UserProfileRepository;
+import qwerty.chaekit.global.security.model.CustomUserDetails;
 
 @Service
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
     private final MemberRepository memberRepository;
+    private final UserProfileRepository userProfileRepository;
+    private final PublisherProfileRepository publisherProfileRepository;
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         Member userData = memberRepository.findByUsername(username)
                 .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 사용자입니다."));
+        Long profileId = null;
+        switch (userData.getRole()) {
+            case ROLE_USER -> profileId = userProfileRepository.findByMember_Id(userData.getId())
+                    .map(UserProfile::getId)
+                    .orElseThrow(() -> new UsernameNotFoundException("사용자 프로필 데이터를 찾을 수 없습니다."));
+            default -> profileId = publisherProfileRepository.findByMember_Id(userData.getId())
+                    .map(PublisherProfile::getId)
+                    .orElseThrow(() -> new UsernameNotFoundException("출판사 프로필 데이터를 찾을 수 없습니다."));
+        }
+
         return new CustomUserDetails(
                 userData.getId(),
+                profileId,
                 userData.getUsername(),
                 userData.getPassword(),
                 userData.getRole().name()

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/security/service/CustomUserDetailsService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/security/service/CustomUserDetailsService.java
@@ -7,11 +7,14 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import qwerty.chaekit.domain.member.Member;
 import qwerty.chaekit.domain.member.MemberRepository;
+import qwerty.chaekit.domain.member.enums.Role;
 import qwerty.chaekit.domain.member.publisher.PublisherProfile;
 import qwerty.chaekit.domain.member.publisher.PublisherProfileRepository;
 import qwerty.chaekit.domain.member.user.UserProfile;
 import qwerty.chaekit.domain.member.user.UserProfileRepository;
 import qwerty.chaekit.global.security.model.CustomUserDetails;
+
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -24,12 +27,13 @@ public class CustomUserDetailsService implements UserDetailsService {
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         Member userData = memberRepository.findByUsername(username)
                 .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 사용자입니다."));
-        Long profileId = null;
-        switch (userData.getRole()) {
-            case ROLE_USER -> profileId = userProfileRepository.findByMember_Id(userData.getId())
+        Long profileId;
+        if (Objects.requireNonNull(userData.getRole()) == Role.ROLE_USER) {
+            profileId = userProfileRepository.findByMember_Id(userData.getId())
                     .map(UserProfile::getId)
                     .orElseThrow(() -> new UsernameNotFoundException("사용자 프로필 데이터를 찾을 수 없습니다."));
-            default -> profileId = publisherProfileRepository.findByMember_Id(userData.getId())
+        } else {
+            profileId = publisherProfileRepository.findByMember_Id(userData.getId())
                     .map(PublisherProfile::getId)
                     .orElseThrow(() -> new UsernameNotFoundException("출판사 프로필 데이터를 찾을 수 없습니다."));
         }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/group/ActivityService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/group/ActivityService.java
@@ -21,7 +21,7 @@ import qwerty.chaekit.global.enums.ErrorCode;
 import qwerty.chaekit.global.exception.BadRequestException;
 import qwerty.chaekit.global.exception.ForbiddenException;
 import qwerty.chaekit.global.exception.NotFoundException;
-import qwerty.chaekit.global.security.resolver.LoginMember;
+import qwerty.chaekit.global.security.resolver.UserToken;
 
 import java.time.LocalDate;
 
@@ -34,9 +34,9 @@ public class ActivityService {
     private final ActivityRepository activityRepository;
     private final EbookRepository ebookRepository;
 
-    public ActivityPostResponse createActivity(LoginMember loginMember, long groupId, ActivityPostRequest request) {
+    public ActivityPostResponse createActivity(UserToken userToken, long groupId, ActivityPostRequest request) {
         // 1. 로그인한 사용자의 프로필을 가져온다.
-        UserProfile userProfile = userRepository.findByMember_Id(loginMember.memberId())
+        UserProfile userProfile = userRepository.findByMember_Id(userToken.memberId())
                 .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
 
         // 2. 모임을 가져온다.
@@ -76,9 +76,9 @@ public class ActivityService {
         return ActivityPostResponse.of(saved);
     }
 
-    public ActivityPostResponse updateActivity(LoginMember loginMember, long groupId, ActivityPatchRequest request) {
+    public ActivityPostResponse updateActivity(UserToken userToken, long groupId, ActivityPatchRequest request) {
         // 1. 사용자 프로필 조회
-        UserProfile userProfile = userRepository.findByMember_Id(loginMember.memberId())
+        UserProfile userProfile = userRepository.findByMember_Id(userToken.memberId())
                 .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
 
         // 2. 그룹 조회

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/group/GroupService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/group/GroupService.java
@@ -14,7 +14,7 @@ import qwerty.chaekit.global.enums.ErrorCode;
 import qwerty.chaekit.dto.page.PageResponse;
 import qwerty.chaekit.global.exception.ForbiddenException;
 import qwerty.chaekit.global.exception.NotFoundException;
-import qwerty.chaekit.global.security.resolver.LoginMember;
+import qwerty.chaekit.global.security.resolver.UserToken;
 
 @Service
 @RequiredArgsConstructor
@@ -23,8 +23,8 @@ public class GroupService {
     private final GroupRepository groupRepository;
 
     @Transactional
-    public GroupPostResponse createGroup(LoginMember loginMember, GroupPostRequest request) {
-        UserProfile userProfile = userProfileRepository.findByMember_Id(loginMember.memberId())
+    public GroupPostResponse createGroup(UserToken userToken, GroupPostRequest request) {
+        UserProfile userProfile = userProfileRepository.findByMember_Id(userToken.memberId())
                 .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
 
         ReadingGroup groupEntity = ReadingGroup.builder()
@@ -51,8 +51,8 @@ public class GroupService {
     }
 
     @Transactional
-    public GroupPostResponse updateGroup(LoginMember loginMember, long groupId, GroupPutRequest request) {
-        UserProfile userProfile = userProfileRepository.findByMember_Id(loginMember.memberId())
+    public GroupPostResponse updateGroup(UserToken userToken, long groupId, GroupPutRequest request) {
+        UserProfile userProfile = userProfileRepository.findByMember_Id(userToken.memberId())
                 .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
 
         ReadingGroup group = groupRepository.findById(groupId)

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/highlight/HighlightService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/highlight/HighlightService.java
@@ -20,8 +20,6 @@ import qwerty.chaekit.global.exception.ForbiddenException;
 import qwerty.chaekit.global.exception.NotFoundException;
 import qwerty.chaekit.global.security.resolver.UserToken;
 
-import java.util.Objects;
-
 @Slf4j
 @Service
 @Transactional
@@ -54,14 +52,14 @@ public class HighlightService {
     }
 
     public PageResponse<HighlightFetchResponse> fetchHighlights(UserToken userToken, Pageable pageable, Long activityId, Long bookId, String spine, Boolean me) {
-        Page<Highlight> highlights = highlightRepository.findHighlights(pageable, userToken.memberId(), activityId, bookId, spine, me);
+        Page<Highlight> highlights = highlightRepository.findHighlights(pageable, userToken.userId(), activityId, bookId, spine, me);
         return PageResponse.of(highlights.map(HighlightFetchResponse::of));
     }
 
     public HighlightPostResponse updateHighlight(UserToken userToken, Long id, HighlightPutRequest request) {
         Highlight highlight = highlightRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.HIGHLIGHT_NOT_FOUND));
-        if(!Objects.equals(userToken.memberId(), highlight.getAuthor().getMember().getId())) {
+        if(!userToken.userId().equals(highlight.getAuthor().getId())) {
             throw new ForbiddenException(ErrorCode.HIGHLIGHT_NOT_YOURS);
         }
         highlight.updateMemo(request.memo());

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/MemberJoinHelper.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/MemberJoinHelper.java
@@ -15,10 +15,10 @@ public class MemberJoinHelper {
     private final MemberRepository memberRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
-    public Member saveMember(String username, String password, Role role) {
-        validateUsername(username);
+    public Member saveMember(String email, String password, Role role) {
+        validateUsername(email);
         return memberRepository.save(Member.builder()
-                .username(username)
+                .username(email)
                 .password(bCryptPasswordEncoder.encode(password))
                 .role(role)
                 .build());

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/admin/AdminService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/admin/AdminService.java
@@ -32,7 +32,7 @@ public class AdminService {
 
     @Transactional
     public boolean acceptPublisher(Long publisherId) {
-        Optional<PublisherProfile> profile = publisherProfileRepository.findByMember_Id(publisherId);
+        Optional<PublisherProfile> profile = publisherProfileRepository.findById(publisherId);
         if (profile.isPresent()) {
             if(profile.get().isAccepted()) {
                 return false;

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/admin/AdminService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/admin/AdminService.java
@@ -19,20 +19,20 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 public class AdminService {
-    private final PublisherProfileRepository publisherProfileRepository;
+    private final PublisherProfileRepository publisherRepository;
     @Getter
     @Setter
     private Long adminPublisherId;
 
     @Transactional(readOnly = true)
     public PageResponse<PublisherInfoResponse> getNotAcceptedPublishers(Pageable pageable) {
-        Page<PublisherProfile> page = publisherProfileRepository.findAllByAcceptedFalseOrderByCreatedAtDesc(pageable);
+        Page<PublisherProfile> page = publisherRepository.findAllByAcceptedFalseOrderByCreatedAtDesc(pageable);
         return PageResponse.of(page.map(PublisherInfoResponse::of));
     }
 
     @Transactional
     public boolean acceptPublisher(Long publisherId) {
-        Optional<PublisherProfile> profile = publisherProfileRepository.findById(publisherId);
+        Optional<PublisherProfile> profile = publisherRepository.findById(publisherId);
         if (profile.isPresent()) {
             if(profile.get().isAccepted()) {
                 return false;

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/admin/AdminService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/admin/AdminService.java
@@ -24,6 +24,10 @@ public class AdminService {
     @Setter
     private Long adminPublisherId;
 
+    @Getter
+    @Setter
+    private Long adminUserId;
+
     @Transactional(readOnly = true)
     public PageResponse<PublisherInfoResponse> getNotAcceptedPublishers(Pageable pageable) {
         Page<PublisherProfile> page = publisherRepository.findAllByAcceptedFalseOrderByCreatedAtDesc(pageable);
@@ -32,12 +36,12 @@ public class AdminService {
 
     @Transactional
     public boolean acceptPublisher(Long publisherId) {
-        Optional<PublisherProfile> profile = publisherRepository.findById(publisherId);
-        if (profile.isPresent()) {
-            if(profile.get().isAccepted()) {
+        Optional<PublisherProfile> publisher = publisherRepository.findById(publisherId);
+        if (publisher.isPresent()) {
+            if(publisher.get().isAccepted()) {
                 return false;
             }
-            profile.get().acceptPublisher();
+            publisher.get().acceptPublisher();
             return true;
         } else {
             throw new NotFoundException(ErrorCode.PUBLISHER_NOT_FOUND);

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/publisher/PublisherJoinService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/publisher/PublisherJoinService.java
@@ -28,9 +28,9 @@ public class PublisherJoinService {
 
         validatePublisherName(request.publisherName());
         Member member = memberJoinHelper.saveMember(email, password, Role.ROLE_PUBLISHER);
-        PublisherProfile profile = saveProfile(request, member);
+        PublisherProfile publisher = savePublisher(request, member);
 
-        return toResponse(request, member, profile);
+        return toResponse(request, member, publisher);
     }
 
     private void validatePublisherName(String name) {
@@ -39,19 +39,19 @@ public class PublisherJoinService {
         }
     }
 
-    private PublisherProfile saveProfile(PublisherJoinRequest request, Member member) {
+    private PublisherProfile savePublisher(PublisherJoinRequest request, Member member) {
         return publisherRepository.save(PublisherProfile.builder()
                 .member(member)
                 .publisherName(request.publisherName())
                 .build());
     }
 
-    private PublisherJoinResponse toResponse(PublisherJoinRequest request, Member member, PublisherProfile profile) {
-        String token = jwtUtil.createJwt(member.getId(), profile.getId(), member.getUsername(), Role.ROLE_PUBLISHER.name());
+    private PublisherJoinResponse toResponse(PublisherJoinRequest request, Member member, PublisherProfile publisher) {
+        String token = jwtUtil.createJwt(member.getId(), null, publisher.getId(), member.getUsername(), Role.ROLE_PUBLISHER.name());
 
         return PublisherJoinResponse.builder()
                 .id(member.getId())
-                .profileId(profile.getId())
+                .publisherId(publisher.getId())
                 .accessToken("Bearer " + token)
                 .username(member.getUsername())
                 .publisherName(request.publisherName())

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/publisher/PublisherJoinService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/publisher/PublisherJoinService.java
@@ -23,14 +23,14 @@ public class PublisherJoinService {
 
     @Transactional
     public PublisherJoinResponse join(PublisherJoinRequest request) {
-        String username = request.username();
+        String email = request.username();
         String password = request.password();
 
         validatePublisherName(request.publisherName());
-        Member member = memberJoinHelper.saveMember(username, password, Role.ROLE_PUBLISHER);
-        saveProfile(request, member);
+        Member member = memberJoinHelper.saveMember(email, password, Role.ROLE_PUBLISHER);
+        PublisherProfile profile = saveProfile(request, member);
 
-        return toResponse(request, member);
+        return toResponse(request, member, profile);
     }
 
     private void validatePublisherName(String name) {
@@ -39,18 +39,19 @@ public class PublisherJoinService {
         }
     }
 
-    private void saveProfile(PublisherJoinRequest request, Member member) {
-        profileRepository.save(PublisherProfile.builder()
+    private PublisherProfile saveProfile(PublisherJoinRequest request, Member member) {
+        return profileRepository.save(PublisherProfile.builder()
                 .member(member)
                 .publisherName(request.publisherName())
                 .build());
     }
 
-    private PublisherJoinResponse toResponse(PublisherJoinRequest request, Member member) {
-        String token = jwtUtil.createJwt(member.getId(), member.getUsername(), Role.ROLE_PUBLISHER.name());
+    private PublisherJoinResponse toResponse(PublisherJoinRequest request, Member member, PublisherProfile profile) {
+        String token = jwtUtil.createJwt(member.getId(), profile.getId(), member.getUsername(), Role.ROLE_PUBLISHER.name());
 
         return PublisherJoinResponse.builder()
                 .id(member.getId())
+                .profileId(profile.getId())
                 .accessToken("Bearer " + token)
                 .username(member.getUsername())
                 .publisherName(request.publisherName())

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/publisher/PublisherJoinService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/publisher/PublisherJoinService.java
@@ -55,7 +55,6 @@ public class PublisherJoinService {
                 .accessToken("Bearer " + token)
                 .username(member.getUsername())
                 .publisherName(request.publisherName())
-                .role(member.getRole().name())
                 .isAccepted(false)
                 .build();
     }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/publisher/PublisherJoinService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/publisher/PublisherJoinService.java
@@ -18,7 +18,7 @@ import qwerty.chaekit.service.member.MemberJoinHelper;
 @RequiredArgsConstructor
 public class PublisherJoinService {
     private final MemberJoinHelper memberJoinHelper;
-    private final PublisherProfileRepository profileRepository;
+    private final PublisherProfileRepository publisherRepository;
     private final JwtUtil jwtUtil;
 
     @Transactional
@@ -34,13 +34,13 @@ public class PublisherJoinService {
     }
 
     private void validatePublisherName(String name) {
-        if (profileRepository.existsByPublisherName(name)) {
+        if (publisherRepository.existsByPublisherName(name)) {
             throw new BadRequestException(ErrorCode.PUBLISHER_ALREADY_EXISTS);
         }
     }
 
     private PublisherProfile saveProfile(PublisherJoinRequest request, Member member) {
-        return profileRepository.save(PublisherProfile.builder()
+        return publisherRepository.save(PublisherProfile.builder()
                 .member(member)
                 .publisherName(request.publisherName())
                 .build());

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/publisher/PublisherService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/publisher/PublisherService.java
@@ -14,10 +14,10 @@ import qwerty.chaekit.global.security.resolver.PublisherToken;
 @Service
 @RequiredArgsConstructor
 public class PublisherService {
-    private final PublisherProfileRepository profileRepository;
+    private final PublisherProfileRepository publisherRepository;
 
     public PublisherMemberResponse getPublisherProfile(PublisherToken token) {
-        PublisherProfile profile = profileRepository.findById(token.publisherId())
+        PublisherProfile profile = publisherRepository.findById(token.publisherId())
                 .orElseThrow(() -> new NotFoundException(ErrorCode.PUBLISHER_NOT_FOUND));
 
         return PublisherMemberResponse.builder()

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/publisher/PublisherService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/publisher/PublisherService.java
@@ -22,8 +22,9 @@ public class PublisherService {
 
         return PublisherMemberResponse.builder()
                 .id(loginMember.memberId())
+                .profileId(profile.getId())
                 .publisherName(profile.getPublisherName())
-                .username(loginMember.username())
+                .username(loginMember.email())
                 .role(loginMember.role())
                 .isAccepted(profile.isAccepted())
                 .build();

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/publisher/PublisherService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/publisher/PublisherService.java
@@ -17,16 +17,16 @@ public class PublisherService {
     private final PublisherProfileRepository publisherRepository;
 
     public PublisherMemberResponse getPublisherProfile(PublisherToken token) {
-        PublisherProfile profile = publisherRepository.findById(token.publisherId())
+        PublisherProfile publisher = publisherRepository.findById(token.publisherId())
                 .orElseThrow(() -> new NotFoundException(ErrorCode.PUBLISHER_NOT_FOUND));
 
         return PublisherMemberResponse.builder()
                 .id(token.memberId())
-                .profileId(profile.getId())
-                .publisherName(profile.getPublisherName())
+                .publisherId(publisher.getId())
+                .publisherName(publisher.getPublisherName())
                 .email(token.email())
                 .role(token.role())
-                .isAccepted(profile.isAccepted())
+                .isAccepted(publisher.isAccepted())
                 .build();
     }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/publisher/PublisherService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/publisher/PublisherService.java
@@ -25,7 +25,6 @@ public class PublisherService {
                 .publisherId(publisher.getId())
                 .publisherName(publisher.getPublisherName())
                 .email(token.email())
-                .role(token.role())
                 .isAccepted(publisher.isAccepted())
                 .build();
     }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/publisher/PublisherService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/publisher/PublisherService.java
@@ -8,7 +8,7 @@ import qwerty.chaekit.domain.member.publisher.PublisherProfileRepository;
 import qwerty.chaekit.dto.member.PublisherMemberResponse;
 import qwerty.chaekit.global.enums.ErrorCode;
 import qwerty.chaekit.global.exception.NotFoundException;
-import qwerty.chaekit.global.security.resolver.LoginMember;
+import qwerty.chaekit.global.security.resolver.UserToken;
 
 @Slf4j
 @Service
@@ -16,16 +16,16 @@ import qwerty.chaekit.global.security.resolver.LoginMember;
 public class PublisherService {
     private final PublisherProfileRepository profileRepository;
 
-    public PublisherMemberResponse getPublisherProfile(LoginMember loginMember) {
-        PublisherProfile profile = profileRepository.findByMember_Id(loginMember.memberId())
+    public PublisherMemberResponse getPublisherProfile(UserToken userToken) {
+        PublisherProfile profile = profileRepository.findByMember_Id(userToken.memberId())
                 .orElseThrow(() -> new NotFoundException(ErrorCode.PUBLISHER_NOT_FOUND));
 
         return PublisherMemberResponse.builder()
-                .id(loginMember.memberId())
+                .id(userToken.memberId())
                 .profileId(profile.getId())
                 .publisherName(profile.getPublisherName())
-                .username(loginMember.email())
-                .role(loginMember.role())
+                .username(userToken.email())
+                .role(userToken.role())
                 .isAccepted(profile.isAccepted())
                 .build();
     }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/publisher/PublisherService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/publisher/PublisherService.java
@@ -8,7 +8,7 @@ import qwerty.chaekit.domain.member.publisher.PublisherProfileRepository;
 import qwerty.chaekit.dto.member.PublisherMemberResponse;
 import qwerty.chaekit.global.enums.ErrorCode;
 import qwerty.chaekit.global.exception.NotFoundException;
-import qwerty.chaekit.global.security.resolver.UserToken;
+import qwerty.chaekit.global.security.resolver.PublisherToken;
 
 @Slf4j
 @Service
@@ -16,16 +16,16 @@ import qwerty.chaekit.global.security.resolver.UserToken;
 public class PublisherService {
     private final PublisherProfileRepository profileRepository;
 
-    public PublisherMemberResponse getPublisherProfile(UserToken userToken) {
-        PublisherProfile profile = profileRepository.findByMember_Id(userToken.memberId())
+    public PublisherMemberResponse getPublisherProfile(PublisherToken token) {
+        PublisherProfile profile = profileRepository.findById(token.publisherId())
                 .orElseThrow(() -> new NotFoundException(ErrorCode.PUBLISHER_NOT_FOUND));
 
         return PublisherMemberResponse.builder()
-                .id(userToken.memberId())
+                .id(token.memberId())
                 .profileId(profile.getId())
                 .publisherName(profile.getPublisherName())
-                .username(userToken.email())
-                .role(userToken.role())
+                .email(token.email())
+                .role(token.role())
                 .isAccepted(profile.isAccepted())
                 .build();
     }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/user/UserJoinService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/user/UserJoinService.java
@@ -23,14 +23,14 @@ public class UserJoinService {
 
     @Transactional
     public UserJoinResponse join(UserJoinRequest request) {
-        String username = request.username();
+        String email = request.username();
         String password = request.password();
 
         validateNickname(request.username());
-        Member member = memberJoinHelper.saveMember(username, password, Role.ROLE_USER);
-        saveProfile(request, member);
+        Member member = memberJoinHelper.saveMember(email, password, Role.ROLE_USER);
+        UserProfile profile = saveProfile(request, member);
 
-        return toResponse(request, member);
+        return toResponse(request, member, profile);
     }
 
     private void validateNickname(String nickname) {
@@ -39,18 +39,19 @@ public class UserJoinService {
         }
     }
 
-    private void saveProfile(UserJoinRequest request, Member member) {
-        userProfileRepository.save(UserProfile.builder()
+    private UserProfile saveProfile(UserJoinRequest request, Member member) {
+        return userProfileRepository.save(UserProfile.builder()
                 .member(member)
                 .nickname(request.nickname())
                 .build());
     }
 
-    private UserJoinResponse toResponse(UserJoinRequest request, Member member) {
-        String token = jwtUtil.createJwt(member.getId(), member.getUsername(), member.getRole().name());
+    private UserJoinResponse toResponse(UserJoinRequest request, Member member, UserProfile userProfile) {
+        String token = jwtUtil.createJwt(member.getId(), userProfile.getId(), member.getUsername(), member.getRole().name());
 
         return UserJoinResponse.builder()
                 .id(member.getId())
+                .profileId(userProfile.getId())
                 .accessToken("Bearer " + token)
                 .username(member.getUsername())
                 .nickname(request.nickname())

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/user/UserJoinService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/user/UserJoinService.java
@@ -28,9 +28,9 @@ public class UserJoinService {
 
         validateNickname(request.username());
         Member member = memberJoinHelper.saveMember(email, password, Role.ROLE_USER);
-        UserProfile profile = saveProfile(request, member);
+        UserProfile user = saveUser(request, member);
 
-        return toResponse(request, member, profile);
+        return toResponse(request, member, user);
     }
 
     private void validateNickname(String nickname) {
@@ -39,19 +39,19 @@ public class UserJoinService {
         }
     }
 
-    private UserProfile saveProfile(UserJoinRequest request, Member member) {
+    private UserProfile saveUser(UserJoinRequest request, Member member) {
         return userRepository.save(UserProfile.builder()
                 .member(member)
                 .nickname(request.nickname())
                 .build());
     }
 
-    private UserJoinResponse toResponse(UserJoinRequest request, Member member, UserProfile userProfile) {
-        String token = jwtUtil.createJwt(member.getId(), userProfile.getId(), member.getUsername(), member.getRole().name());
+    private UserJoinResponse toResponse(UserJoinRequest request, Member member, UserProfile user) {
+        String token = jwtUtil.createJwt(member.getId(), user.getId(), null, member.getUsername(), member.getRole().name());
 
         return UserJoinResponse.builder()
                 .id(member.getId())
-                .profileId(userProfile.getId())
+                .userId(user.getId())
                 .accessToken("Bearer " + token)
                 .username(member.getUsername())
                 .nickname(request.nickname())

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/user/UserJoinService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/user/UserJoinService.java
@@ -55,7 +55,6 @@ public class UserJoinService {
                 .accessToken("Bearer " + token)
                 .username(member.getUsername())
                 .nickname(request.nickname())
-                .role(member.getRole().name())
                 .build();
     }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/user/UserJoinService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/user/UserJoinService.java
@@ -18,7 +18,7 @@ import qwerty.chaekit.service.member.MemberJoinHelper;
 @RequiredArgsConstructor
 public class UserJoinService {
     private final MemberJoinHelper memberJoinHelper;
-    private final UserProfileRepository userProfileRepository;
+    private final UserProfileRepository userRepository;
     private final JwtUtil jwtUtil;
 
     @Transactional
@@ -34,13 +34,13 @@ public class UserJoinService {
     }
 
     private void validateNickname(String nickname) {
-        if (userProfileRepository.existsByNickname(nickname)) {
+        if (userRepository.existsByNickname(nickname)) {
             throw new BadRequestException(ErrorCode.NICKNAME_ALREADY_EXISTS);
         }
     }
 
     private UserProfile saveProfile(UserJoinRequest request, Member member) {
-        return userProfileRepository.save(UserProfile.builder()
+        return userRepository.save(UserProfile.builder()
                 .member(member)
                 .nickname(request.nickname())
                 .build());

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/user/UserService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/user/UserService.java
@@ -13,10 +13,10 @@ import qwerty.chaekit.global.security.resolver.UserToken;
 @Service
 @RequiredArgsConstructor
 public class UserService {
-    private final UserProfileRepository profileRepository;
+    private final UserProfileRepository userRepository;
 
     public UserMemberResponse getUserProfile(UserToken userToken) {
-        String nickname = profileRepository.findById(userToken.userId())
+        String nickname = userRepository.findById(userToken.userId())
                 .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND)).getNickname();
 
         return UserMemberResponse.builder()

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/user/UserService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/user/UserService.java
@@ -24,7 +24,6 @@ public class UserService {
                 .userId(userToken.userId())
                 .username(userToken.email())
                 .nickname(nickname)
-                .role(userToken.role())
                 .build();
     }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/user/UserService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/user/UserService.java
@@ -16,13 +16,14 @@ public class UserService {
     private final UserProfileRepository profileRepository;
 
     public UserMemberResponse getUserProfile(LoginMember loginMember) {
-        String nickname = profileRepository.findByMember_Id(loginMember.memberId())
+        String nickname = profileRepository.findById(loginMember.profileId())
                 .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND)).getNickname();
 
         return UserMemberResponse.builder()
                 .id(loginMember.memberId())
+                .profileId(loginMember.profileId())
+                .username(loginMember.email())
                 .nickname(nickname)
-                .username(loginMember.username())
                 .role(loginMember.role())
                 .build();
     }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/user/UserService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/user/UserService.java
@@ -7,7 +7,7 @@ import qwerty.chaekit.domain.member.user.UserProfileRepository;
 import qwerty.chaekit.dto.member.UserMemberResponse;
 import qwerty.chaekit.global.enums.ErrorCode;
 import qwerty.chaekit.global.exception.NotFoundException;
-import qwerty.chaekit.global.security.resolver.LoginMember;
+import qwerty.chaekit.global.security.resolver.UserToken;
 
 @Slf4j
 @Service
@@ -15,16 +15,16 @@ import qwerty.chaekit.global.security.resolver.LoginMember;
 public class UserService {
     private final UserProfileRepository profileRepository;
 
-    public UserMemberResponse getUserProfile(LoginMember loginMember) {
-        String nickname = profileRepository.findById(loginMember.profileId())
+    public UserMemberResponse getUserProfile(UserToken userToken) {
+        String nickname = profileRepository.findById(userToken.userId())
                 .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND)).getNickname();
 
         return UserMemberResponse.builder()
-                .id(loginMember.memberId())
-                .profileId(loginMember.profileId())
-                .username(loginMember.email())
+                .id(userToken.memberId())
+                .profileId(userToken.userId())
+                .username(userToken.email())
                 .nickname(nickname)
-                .role(loginMember.role())
+                .role(userToken.role())
                 .build();
     }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/member/user/UserService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/member/user/UserService.java
@@ -21,7 +21,7 @@ public class UserService {
 
         return UserMemberResponse.builder()
                 .id(userToken.memberId())
-                .profileId(userToken.userId())
+                .userId(userToken.userId())
                 .username(userToken.email())
                 .nickname(nickname)
                 .role(userToken.role())

--- a/chaekit-spring/src/main/resources/db/migration/V2__remove_wrong_constraint.sql
+++ b/chaekit-spring/src/main/resources/db/migration/V2__remove_wrong_constraint.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ebook
+DROP FOREIGN KEY FKfxsj468a7v1h63gc6jdbwhovu;

--- a/chaekit-spring/src/test/java/qwerty/chaekit/ChaekitApplicationTests.java
+++ b/chaekit-spring/src/test/java/qwerty/chaekit/ChaekitApplicationTests.java
@@ -2,7 +2,9 @@ package qwerty.chaekit;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class ChaekitApplicationTests {
 

--- a/chaekit-spring/src/test/java/qwerty/chaekit/service/AdminServiceTest.java
+++ b/chaekit-spring/src/test/java/qwerty/chaekit/service/AdminServiceTest.java
@@ -32,7 +32,7 @@ class AdminServiceTest {
         Long publisherId = 1L;
         PublisherProfile profile = mock(PublisherProfile.class);
         given(profile.isAccepted()).willReturn(false);
-        given(publisherProfileRepository.findByMember_Id(publisherId))
+        given(publisherProfileRepository.findById(publisherId))
                 .willReturn(Optional.of(profile));
         // when
         boolean result = adminService.acceptPublisher(publisherId);
@@ -48,7 +48,7 @@ class AdminServiceTest {
         Long publisherId = 2L;
         PublisherProfile profile = mock(PublisherProfile.class);
         given(profile.isAccepted()).willReturn(true);
-        given(publisherProfileRepository.findByMember_Id(publisherId))
+        given(publisherProfileRepository.findById(publisherId))
                 .willReturn(Optional.of(profile));
         // when
         boolean result = adminService.acceptPublisher(publisherId);
@@ -62,7 +62,7 @@ class AdminServiceTest {
     void test3() {
         // given
         Long publisherId = 3L;
-        given(publisherProfileRepository.findByMember_Id(publisherId))
+        given(publisherProfileRepository.findById(publisherId))
                 .willReturn(Optional.empty());
         // when
         NotFoundException e = assertThrows(NotFoundException.class, () ->

--- a/chaekit-spring/src/test/java/qwerty/chaekit/service/AdminServiceTest.java
+++ b/chaekit-spring/src/test/java/qwerty/chaekit/service/AdminServiceTest.java
@@ -30,15 +30,15 @@ class AdminServiceTest {
     void test1() {
         // given
         Long publisherId = 1L;
-        PublisherProfile profile = mock(PublisherProfile.class);
-        given(profile.isAccepted()).willReturn(false);
+        PublisherProfile publisher = mock(PublisherProfile.class);
+        given(publisher.isAccepted()).willReturn(false);
         given(publisherProfileRepository.findById(publisherId))
-                .willReturn(Optional.of(profile));
+                .willReturn(Optional.of(publisher));
         // when
         boolean result = adminService.acceptPublisher(publisherId);
         // then
         assertTrue(result);
-        verify(profile).acceptPublisher();
+        verify(publisher).acceptPublisher();
     }
 
     @Test
@@ -46,15 +46,15 @@ class AdminServiceTest {
     void test2() {
         // given
         Long publisherId = 2L;
-        PublisherProfile profile = mock(PublisherProfile.class);
-        given(profile.isAccepted()).willReturn(true);
+        PublisherProfile publisher = mock(PublisherProfile.class);
+        given(publisher.isAccepted()).willReturn(true);
         given(publisherProfileRepository.findById(publisherId))
-                .willReturn(Optional.of(profile));
+                .willReturn(Optional.of(publisher));
         // when
         boolean result = adminService.acceptPublisher(publisherId);
         // then
         assertFalse(result);
-        verify(profile, never()).acceptPublisher();
+        verify(publisher, never()).acceptPublisher();
     }
 
     @Test

--- a/chaekit-spring/src/test/java/qwerty/chaekit/service/group/ActivityServiceTest.java
+++ b/chaekit-spring/src/test/java/qwerty/chaekit/service/group/ActivityServiceTest.java
@@ -22,7 +22,7 @@ import qwerty.chaekit.dto.group.activity.ActivityPostResponse;
 import qwerty.chaekit.dto.page.PageResponse;
 import qwerty.chaekit.global.exception.BadRequestException;
 import qwerty.chaekit.global.exception.ForbiddenException;
-import qwerty.chaekit.global.security.resolver.LoginMember;
+import qwerty.chaekit.global.security.resolver.UserToken;
 import qwerty.chaekit.util.TestFixtureFactory;
 
 import java.time.LocalDate;
@@ -43,8 +43,8 @@ class ActivityServiceTest {
     @Autowired
     private TestFixtureFactory testFixtureFactory;
 
-    private LoginMember groupLeaderLogin;
-    private LoginMember anotherLogin;
+    private UserToken groupLeaderLogin;
+    private UserToken anotherLogin;
     private ReadingGroup dummyGroup;
     private Ebook dummyEbook;
 

--- a/chaekit-spring/src/test/java/qwerty/chaekit/service/group/ActivityServiceTest.java
+++ b/chaekit-spring/src/test/java/qwerty/chaekit/service/group/ActivityServiceTest.java
@@ -52,8 +52,8 @@ class ActivityServiceTest {
     void setUp() {
         UserProfile groupLeader = testFixtureFactory.createUser("leader_username", "leader_nickname");
         UserProfile anotherUser = testFixtureFactory.createUser("user_username", "user_nickname");
-        groupLeaderLogin = testFixtureFactory.createLoginMember(groupLeader.getMember(), Role.ROLE_USER);
-        anotherLogin = testFixtureFactory.createLoginMember(anotherUser.getMember(), Role.ROLE_USER);
+        groupLeaderLogin = testFixtureFactory.createUserToken(groupLeader.getMember(), groupLeader, Role.ROLE_USER);
+        anotherLogin = testFixtureFactory.createUserToken(anotherUser.getMember(), anotherUser, Role.ROLE_USER);
 
         PublisherProfile publisher = testFixtureFactory.createPublisher("publisher_username", "publisher_name");
         dummyEbook = testFixtureFactory.createEbook("dummy_ebook", publisher, "author", "description", "file_key");

--- a/chaekit-spring/src/test/java/qwerty/chaekit/service/group/ActivityServiceTest.java
+++ b/chaekit-spring/src/test/java/qwerty/chaekit/service/group/ActivityServiceTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 import qwerty.chaekit.domain.ebook.Ebook;
 import qwerty.chaekit.domain.group.ReadingGroup;
@@ -30,6 +31,7 @@ import java.time.LocalDate;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @Transactional
 class ActivityServiceTest {

--- a/chaekit-spring/src/test/java/qwerty/chaekit/service/group/ActivityServiceTest.java
+++ b/chaekit-spring/src/test/java/qwerty/chaekit/service/group/ActivityServiceTest.java
@@ -13,7 +13,6 @@ import qwerty.chaekit.domain.ebook.Ebook;
 import qwerty.chaekit.domain.group.ReadingGroup;
 import qwerty.chaekit.domain.group.activity.Activity;
 import qwerty.chaekit.domain.group.activity.ActivityRepository;
-import qwerty.chaekit.domain.member.enums.Role;
 import qwerty.chaekit.domain.member.publisher.PublisherProfile;
 import qwerty.chaekit.domain.member.user.UserProfile;
 import qwerty.chaekit.dto.group.activity.ActivityFetchResponse;

--- a/chaekit-spring/src/test/java/qwerty/chaekit/service/group/ActivityServiceTest.java
+++ b/chaekit-spring/src/test/java/qwerty/chaekit/service/group/ActivityServiceTest.java
@@ -54,8 +54,8 @@ class ActivityServiceTest {
     void setUp() {
         UserProfile groupLeader = testFixtureFactory.createUser("leader_username", "leader_nickname");
         UserProfile anotherUser = testFixtureFactory.createUser("user_username", "user_nickname");
-        groupLeaderLogin = testFixtureFactory.createUserToken(groupLeader.getMember(), groupLeader, Role.ROLE_USER);
-        anotherLogin = testFixtureFactory.createUserToken(anotherUser.getMember(), anotherUser, Role.ROLE_USER);
+        groupLeaderLogin = testFixtureFactory.createUserToken(groupLeader.getMember(), groupLeader);
+        anotherLogin = testFixtureFactory.createUserToken(anotherUser.getMember(), anotherUser);
 
         PublisherProfile publisher = testFixtureFactory.createPublisher("publisher_username", "publisher_name");
         dummyEbook = testFixtureFactory.createEbook("dummy_ebook", publisher, "author", "description", "file_key");

--- a/chaekit-spring/src/test/java/qwerty/chaekit/service/highlight/HighlightServiceTest.java
+++ b/chaekit-spring/src/test/java/qwerty/chaekit/service/highlight/HighlightServiceTest.java
@@ -48,7 +48,7 @@ class HighlightServiceTest {
         dummyUserProfile = testFixtureFactory.createUser("user_username", "user_nickname");
         PublisherProfile dummyPublisherProfile = testFixtureFactory.createPublisher("publisher_username", "publisher_name");
         dummyEbook = testFixtureFactory.createEbook("dummy_ebook", dummyPublisherProfile, "book_author", "book_description", "book_file_key");
-        dummyUserToken = testFixtureFactory.createLoginMember(dummyUserProfile.getMember(), Role.ROLE_USER);
+        dummyUserToken = testFixtureFactory.createUserToken(dummyUserProfile.getMember(), dummyUserProfile, Role.ROLE_USER);
 
     }
 
@@ -146,7 +146,7 @@ class HighlightServiceTest {
                 .build());
 
         UserProfile anotherUserProfile = testFixtureFactory.createUser("another_user", "another_nickname");
-        UserToken anotherUserToken = testFixtureFactory.createLoginMember(anotherUserProfile.getMember(), Role.ROLE_USER);
+        UserToken anotherUserToken = testFixtureFactory.createUserToken(anotherUserProfile.getMember(), anotherUserProfile, Role.ROLE_USER);
         HighlightPutRequest request = HighlightPutRequest.builder()
                 .memo("Updated Memo")
                 .build();

--- a/chaekit-spring/src/test/java/qwerty/chaekit/service/highlight/HighlightServiceTest.java
+++ b/chaekit-spring/src/test/java/qwerty/chaekit/service/highlight/HighlightServiceTest.java
@@ -41,16 +41,16 @@ class HighlightServiceTest {
     @Autowired
     private TestFixtureFactory testFixtureFactory;
 
-    private UserProfile dummyUserProfile;
+    private UserProfile dummyUser;
     private Ebook dummyEbook;
     private UserToken dummyUserToken;
 
     @BeforeEach
     void setUp() {
-        dummyUserProfile = testFixtureFactory.createUser("user_username", "user_nickname");
+        dummyUser = testFixtureFactory.createUser("user_username", "user_nickname");
         PublisherProfile dummyPublisherProfile = testFixtureFactory.createPublisher("publisher_username", "publisher_name");
         dummyEbook = testFixtureFactory.createEbook("dummy_ebook", dummyPublisherProfile, "book_author", "book_description", "book_file_key");
-        dummyUserToken = testFixtureFactory.createUserToken(dummyUserProfile.getMember(), dummyUserProfile, Role.ROLE_USER);
+        dummyUserToken = testFixtureFactory.createUserToken(dummyUser.getMember(), dummyUser, Role.ROLE_USER);
 
     }
 
@@ -81,7 +81,7 @@ class HighlightServiceTest {
     void fetchHighlightsTest() {
         // Given
         Highlight highlight = highlightRepository.save(Highlight.builder()
-                .author(dummyUserProfile)
+                .author(dummyUser)
                 .book(dummyEbook)
                 .spine("spine1")
                 .cfi("cfi1")
@@ -113,7 +113,7 @@ class HighlightServiceTest {
     void updateHighlightTest() {
         // Given
         Highlight highlight = highlightRepository.save(Highlight.builder()
-                .author(dummyUserProfile)
+                .author(dummyUser)
                 .book(dummyEbook)
                 .spine("spine1")
                 .cfi("cfi1")
@@ -140,7 +140,7 @@ class HighlightServiceTest {
     void updateHighlightForbiddenTest() {
         // Given
         Highlight highlight = highlightRepository.save(Highlight.builder()
-                .author(dummyUserProfile)
+                .author(dummyUser)
                 .book(dummyEbook)
                 .spine("spine1")
                 .cfi("cfi1")

--- a/chaekit-spring/src/test/java/qwerty/chaekit/service/highlight/HighlightServiceTest.java
+++ b/chaekit-spring/src/test/java/qwerty/chaekit/service/highlight/HighlightServiceTest.java
@@ -19,7 +19,7 @@ import qwerty.chaekit.dto.highlight.HighlightPostRequest;
 import qwerty.chaekit.dto.highlight.HighlightPostResponse;
 import qwerty.chaekit.dto.highlight.HighlightPutRequest;
 import qwerty.chaekit.dto.page.PageResponse;
-import qwerty.chaekit.global.security.resolver.LoginMember;
+import qwerty.chaekit.global.security.resolver.UserToken;
 import qwerty.chaekit.util.TestFixtureFactory;
 
 import java.util.Optional;
@@ -41,14 +41,14 @@ class HighlightServiceTest {
 
     private UserProfile dummyUserProfile;
     private Ebook dummyEbook;
-    private LoginMember dummyLoginMember;
+    private UserToken dummyUserToken;
 
     @BeforeEach
     void setUp() {
         dummyUserProfile = testFixtureFactory.createUser("user_username", "user_nickname");
         PublisherProfile dummyPublisherProfile = testFixtureFactory.createPublisher("publisher_username", "publisher_name");
         dummyEbook = testFixtureFactory.createEbook("dummy_ebook", dummyPublisherProfile, "book_author", "book_description", "book_file_key");
-        dummyLoginMember = testFixtureFactory.createLoginMember(dummyUserProfile.getMember(), Role.ROLE_USER);
+        dummyUserToken = testFixtureFactory.createLoginMember(dummyUserProfile.getMember(), Role.ROLE_USER);
 
     }
 
@@ -64,7 +64,7 @@ class HighlightServiceTest {
                 .build();
 
         // When
-        HighlightPostResponse response = highlightService.createHighlight(dummyLoginMember, request);
+        HighlightPostResponse response = highlightService.createHighlight(dummyUserToken, request);
 
         // Then
         assertThat(response).isNotNull();
@@ -90,7 +90,7 @@ class HighlightServiceTest {
 
         // When
         PageResponse<HighlightFetchResponse> response = highlightService.fetchHighlights(
-                dummyLoginMember,
+                dummyUserToken,
                 pageable,
                 null,
                 dummyEbook.getId(),
@@ -122,7 +122,7 @@ class HighlightServiceTest {
                 .build();
 
         // When
-        HighlightPostResponse response = highlightService.updateHighlight(dummyLoginMember, highlight.getId(), request);
+        HighlightPostResponse response = highlightService.updateHighlight(dummyUserToken, highlight.getId(), request);
 
         // Then
         assertThat(response).isNotNull();
@@ -146,12 +146,12 @@ class HighlightServiceTest {
                 .build());
 
         UserProfile anotherUserProfile = testFixtureFactory.createUser("another_user", "another_nickname");
-        LoginMember anotherLoginMember = testFixtureFactory.createLoginMember(anotherUserProfile.getMember(), Role.ROLE_USER);
+        UserToken anotherUserToken = testFixtureFactory.createLoginMember(anotherUserProfile.getMember(), Role.ROLE_USER);
         HighlightPutRequest request = HighlightPutRequest.builder()
                 .memo("Updated Memo")
                 .build();
 
         // When & Then
-        assertThrows(Exception.class, () -> highlightService.updateHighlight(anotherLoginMember, highlight.getId(), request));
+        assertThrows(Exception.class, () -> highlightService.updateHighlight(anotherUserToken, highlight.getId(), request));
     }
 }

--- a/chaekit-spring/src/test/java/qwerty/chaekit/service/highlight/HighlightServiceTest.java
+++ b/chaekit-spring/src/test/java/qwerty/chaekit/service/highlight/HighlightServiceTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 import qwerty.chaekit.domain.ebook.Ebook;
 import qwerty.chaekit.domain.highlight.entity.Highlight;
@@ -27,6 +28,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @Transactional
 class HighlightServiceTest {

--- a/chaekit-spring/src/test/java/qwerty/chaekit/service/highlight/HighlightServiceTest.java
+++ b/chaekit-spring/src/test/java/qwerty/chaekit/service/highlight/HighlightServiceTest.java
@@ -12,7 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 import qwerty.chaekit.domain.ebook.Ebook;
 import qwerty.chaekit.domain.highlight.entity.Highlight;
 import qwerty.chaekit.domain.highlight.repository.HighlightRepository;
-import qwerty.chaekit.domain.member.enums.Role;
 import qwerty.chaekit.domain.member.publisher.PublisherProfile;
 import qwerty.chaekit.domain.member.user.UserProfile;
 import qwerty.chaekit.dto.highlight.HighlightFetchResponse;
@@ -50,7 +49,7 @@ class HighlightServiceTest {
         dummyUser = testFixtureFactory.createUser("user_username", "user_nickname");
         PublisherProfile dummyPublisherProfile = testFixtureFactory.createPublisher("publisher_username", "publisher_name");
         dummyEbook = testFixtureFactory.createEbook("dummy_ebook", dummyPublisherProfile, "book_author", "book_description", "book_file_key");
-        dummyUserToken = testFixtureFactory.createUserToken(dummyUser.getMember(), dummyUser, Role.ROLE_USER);
+        dummyUserToken = testFixtureFactory.createUserToken(dummyUser.getMember(), dummyUser);
 
     }
 
@@ -148,7 +147,7 @@ class HighlightServiceTest {
                 .build());
 
         UserProfile anotherUserProfile = testFixtureFactory.createUser("another_user", "another_nickname");
-        UserToken anotherUserToken = testFixtureFactory.createUserToken(anotherUserProfile.getMember(), anotherUserProfile, Role.ROLE_USER);
+        UserToken anotherUserToken = testFixtureFactory.createUserToken(anotherUserProfile.getMember(), anotherUserProfile);
         HighlightPutRequest request = HighlightPutRequest.builder()
                 .memo("Updated Memo")
                 .build();

--- a/chaekit-spring/src/test/java/qwerty/chaekit/util/TestFixtureFactory.java
+++ b/chaekit-spring/src/test/java/qwerty/chaekit/util/TestFixtureFactory.java
@@ -46,19 +46,19 @@ public class TestFixtureFactory {
         );
     }
 
-    public UserToken createUserToken(Member member, UserProfile profile, Role role) {
+    public UserToken createUserToken(Member member, UserProfile user, Role role) {
         return UserToken.builder()
                 .memberId(member.getId())
-                .userId(profile.getId())
+                .userId(user.getId())
                 .email(member.getUsername())
                 .role(role.name())
                 .build();
     }
 
-    public PublisherToken createPublisherToken(Member member, PublisherProfile profile, Role role) {
+    public PublisherToken createPublisherToken(Member member, PublisherProfile publisher, Role role) {
         return PublisherToken.builder()
                 .memberId(member.getId())
-                .publisherId(profile.getId())
+                .publisherId(publisher.getId())
                 .email(member.getUsername())
                 .role(role.name())
                 .build();

--- a/chaekit-spring/src/test/java/qwerty/chaekit/util/TestFixtureFactory.java
+++ b/chaekit-spring/src/test/java/qwerty/chaekit/util/TestFixtureFactory.java
@@ -13,7 +13,7 @@ import qwerty.chaekit.domain.member.publisher.PublisherProfile;
 import qwerty.chaekit.domain.member.publisher.PublisherProfileRepository;
 import qwerty.chaekit.domain.member.user.UserProfile;
 import qwerty.chaekit.domain.member.user.UserProfileRepository;
-import qwerty.chaekit.global.security.resolver.LoginMember;
+import qwerty.chaekit.global.security.resolver.UserToken;
 
 @Component
 public class TestFixtureFactory {
@@ -45,8 +45,8 @@ public class TestFixtureFactory {
         );
     }
 
-    public LoginMember createLoginMember(Member member, Role role) {
-        return LoginMember.builder()
+    public UserToken createLoginMember(Member member, Role role) {
+        return UserToken.builder()
                 .memberId(member.getId())
                 .username(member.getUsername())
                 .role(role.name())

--- a/chaekit-spring/src/test/java/qwerty/chaekit/util/TestFixtureFactory.java
+++ b/chaekit-spring/src/test/java/qwerty/chaekit/util/TestFixtureFactory.java
@@ -13,6 +13,7 @@ import qwerty.chaekit.domain.member.publisher.PublisherProfile;
 import qwerty.chaekit.domain.member.publisher.PublisherProfileRepository;
 import qwerty.chaekit.domain.member.user.UserProfile;
 import qwerty.chaekit.domain.member.user.UserProfileRepository;
+import qwerty.chaekit.global.security.resolver.PublisherToken;
 import qwerty.chaekit.global.security.resolver.UserToken;
 
 @Component
@@ -45,10 +46,20 @@ public class TestFixtureFactory {
         );
     }
 
-    public UserToken createLoginMember(Member member, Role role) {
+    public UserToken createUserToken(Member member, UserProfile profile, Role role) {
         return UserToken.builder()
                 .memberId(member.getId())
-                .username(member.getUsername())
+                .userId(profile.getId())
+                .email(member.getUsername())
+                .role(role.name())
+                .build();
+    }
+
+    public PublisherToken createPublisherToken(Member member, PublisherProfile profile, Role role) {
+        return PublisherToken.builder()
+                .memberId(member.getId())
+                .publisherId(profile.getId())
+                .email(member.getUsername())
                 .role(role.name())
                 .build();
     }

--- a/chaekit-spring/src/test/java/qwerty/chaekit/util/TestFixtureFactory.java
+++ b/chaekit-spring/src/test/java/qwerty/chaekit/util/TestFixtureFactory.java
@@ -46,21 +46,19 @@ public class TestFixtureFactory {
         );
     }
 
-    public UserToken createUserToken(Member member, UserProfile user, Role role) {
+    public UserToken createUserToken(Member member, UserProfile user) {
         return UserToken.builder()
                 .memberId(member.getId())
                 .userId(user.getId())
                 .email(member.getUsername())
-                .role(role.name())
                 .build();
     }
 
-    public PublisherToken createPublisherToken(Member member, PublisherProfile publisher, Role role) {
+    public PublisherToken createPublisherToken(Member member, PublisherProfile publisher) {
         return PublisherToken.builder()
                 .memberId(member.getId())
                 .publisherId(publisher.getId())
                 .email(member.getUsername())
-                .role(role.name())
                 .build();
     }
 

--- a/chaekit-spring/src/test/resources/application-test.yml
+++ b/chaekit-spring/src/test/resources/application-test.yml
@@ -13,3 +13,5 @@ spring:
   h2:
     console:
       enabled: true
+  flyway:
+    enabled: false


### PR DESCRIPTION
## ✨ 작업 개요
jwt 구조 변경 및 @Login 기능 변경

## ✅ 작업 내용
- jwt에 "userId", "publisherId" 추가
- 일반 회원, 출판사 회원 조회 응답에 userId, publisherId 프로퍼티 추가
- LoginMember -> UserToken, PublisherToken으로 분리
- 이름 리팩토링
- minor fix

## 💬 기타
@Login을 컨트롤러 파라미터에 사용하면 반드시 로그인 된 사용자이며 User 혹은 Publisher이어야함.
Admin은 두 권한 모두 보유(userId, publisherId 모두 사용 가능)