### PR TITLE
[FIX] 클라이언트 배포 삭제 수정

### DIFF
--- a/client/cdk/lib/ClientDeploymentStack.ts
+++ b/client/cdk/lib/ClientDeploymentStack.ts
@@ -79,12 +79,26 @@ export class ClientDeploymentStack extends cdk.Stack {
     );
 
     // ==============================================================
-    new cdk.aws_s3_deployment.BucketDeployment(this, "DeployClient", {
-      sources: [cdk.aws_s3_deployment.Source.asset("../dist")],
-      destinationBucket: bucket,
-      distribution: cloudFront,
-      distributionPaths: ["/*"],
-    });
+    const deployment = new cdk.aws_s3_deployment.BucketDeployment(
+      this,
+      "DeployClient",
+      {
+        sources: [cdk.aws_s3_deployment.Source.asset("../dist")],
+        destinationBucket: bucket,
+        distribution: cloudFront,
+        distributionPaths: ["/*"],
+      }
+    );
+    deployment.handlerRole.addToPrincipalPolicy(
+      new cdk.aws_iam.PolicyStatement({
+        effect: cdk.aws_iam.Effect.ALLOW,
+        actions: [
+          "cloudFront:GetInvalidation",
+          "cloudFront:CreateInvalidation",
+        ],
+        resources: ["*"],
+      })
+    );
 
     // ==============================================================
     new cdk.aws_route53.ARecord(this, "ClientRecord", {


### PR DESCRIPTION
## ✨ 작업 개요
클라이언트 배포 삭제 수정

## ✅ 작업 내용
- 스택 삭제 중 버킷이 버킷 디플로이보다 먼저 삭제되어 클라우드 프론트 무효화를 발생시키려 할 때 권한이 없는 문제가 발생
  - 버킷 디플로이에 클라우드 프론트 무효화 권한을 수동으로 부여

## 📎 관련 이슈

## 🧪 테스트 방법

## 💬 기타
