### PR TITLE
[CHORE] 탑 바에 페이지 이동 버튼들 추가

### DIFF
--- a/client/src/component/AppBar.tsx
+++ b/client/src/component/AppBar.tsx
@@ -1,4 +1,4 @@
-import { Toolbar, AppBar as MuiAppBar, Button } from "@mui/material";
+import { Toolbar, AppBar as MuiAppBar, Button, Divider } from "@mui/material";
 import { createLink, Link, LinkComponentProps } from "@tanstack/react-router";
 import { useAtomValue } from "jotai";
 import { AuthState } from "../states/auth";
@@ -16,12 +16,14 @@ export default function AppBar() {
         <LogoButton to="/" sx={{ mr: "auto" }}>
           <img src="/logoTitle.png" alt="Logo" height={40} />
         </LogoButton>
+        <LinkNavButton to={"/books"} text="도서" />
+        <LinkNavButton to={"/groups"} text="모임" />
+        <Divider orientation="vertical" flexItem variant="middle" />
         {user && user.role === Role.ROLE_ADMIN && (
           <LinkNavButton to={"/admin"} text="관리자" />
         )}
         {user ? (
           <>
-            <LinkNavButton to={"/books"} text="도서" />
             <LinkNavButton to={"/mypage"} text="마이페이지" />
             <Button onClick={logout}>로그아웃</Button>
           </>
@@ -41,7 +43,12 @@ function LinkNavButton(props: { to: LinkComponentProps["to"]; text: string }) {
     <Link to={to}>
       {({ isActive }) => {
         return (
-          <Button color={isActive ? "primary" : "secondary"}>{text}</Button>
+          <Button
+            color={isActive ? "primary" : "secondary"}
+            sx={{ fontWeight: isActive ? "bold" : "regular" }}
+          >
+            {text}
+          </Button>
         );
       }}
     </Link>

--- a/client/src/component/AppBar.tsx
+++ b/client/src/component/AppBar.tsx
@@ -1,5 +1,5 @@
 import { Toolbar, AppBar as MuiAppBar, Button } from "@mui/material";
-import { createLink, Link } from "@tanstack/react-router";
+import { createLink, Link, LinkComponentProps } from "@tanstack/react-router";
 import { useAtomValue } from "jotai";
 import { AuthState } from "../states/auth";
 import { Role } from "../types/role";
@@ -16,30 +16,17 @@ export default function AppBar() {
         <LogoButton to="/" sx={{ mr: "auto" }}>
           <img src="/logoTitle.png" alt="Logo" height={40} />
         </LogoButton>
-
         {user && user.role === Role.ROLE_ADMIN && (
-          <Link to="/admin">
-            {({ isActive }) => {
-              return (
-                <Button color={isActive ? "primary" : "secondary"}>
-                  관리자
-                </Button>
-              );
-            }}
-          </Link>
+          <LinkNavButton to={"/admin"} text="관리자" />
         )}
         {user ? (
-          <Button onClick={logout}>로그아웃</Button>
+          <>
+            <LinkNavButton to={"/books"} text="도서" />
+            <LinkNavButton to={"/mypage"} text="마이페이지" />
+            <Button onClick={logout}>로그아웃</Button>
+          </>
         ) : (
-          <Link to="/login">
-            {({ isActive }) => {
-              return (
-                <Button color={isActive ? "primary" : "secondary"}>
-                  로그인
-                </Button>
-              );
-            }}
-          </Link>
+          <LinkNavButton to={"/login"} text="로그인" />
         )}
       </Toolbar>
     </MuiAppBar>
@@ -47,3 +34,16 @@ export default function AppBar() {
 }
 
 const LogoButton = createLink(Button);
+
+function LinkNavButton(props: { to: LinkComponentProps["to"]; text: string }) {
+  const { to, text } = props;
+  return (
+    <Link to={to}>
+      {({ isActive }) => {
+        return (
+          <Button color={isActive ? "primary" : "secondary"}>{text}</Button>
+        );
+      }}
+    </Link>
+  );
+}


### PR DESCRIPTION
## ✨ 작업 개요
탑 바에 페이지 이동 버튼들 추가

## ✅ 작업 내용
- 탑바 nav 버튼 스타일 개선
- 모임, 책, 마이페이지 네비게이션 버튼 추가

## 📎 관련 이슈

## 🧪 테스트 방법

## 💬 기타
