### PR TITLE
[CHORE] elasticahce 해제

### DIFF
--- a/chaekit-spring/src/main/resources/application-dev.yml
+++ b/chaekit-spring/src/main/resources/application-dev.yml
@@ -4,4 +4,4 @@ spring:
       host: ${REDIS_URL}
       port: 6379
       ssl:
-        enabled: true
+        enabled: false


### PR DESCRIPTION
## ✨ 작업 개요
aws ElastiCache 해제 후 ec2에 redis 배포

## ✅ 작업 내용
- elastiCache 서비스 삭제
- redis용 ec2 인스턴스 생성 및 설정
- REDIS_URL 시크릿 환경 변수 수정
- ssl 연결설정 해제

## 💬 기타
ElastiCache 비용이 너무 비싸므로 ec2에 redis 설치하고 배포
