### PR TITLE
[FEAT][FE] 그룹, 책 이미지 지원

### DIFF
--- a/client/src/component/groupCreate/GroupCreateModal.tsx
+++ b/client/src/component/groupCreate/GroupCreateModal.tsx
@@ -1,4 +1,4 @@
-import { Box, Container, Modal } from "@mui/material";
+import { Container, Modal } from "@mui/material";
 import GroupEditForm, { GroupEditData } from "./GroupEditForm";
 import API_CLIENT, { wrapApiResponse } from "../../api/api";
 import { useNavigate } from "@tanstack/react-router";
@@ -12,13 +12,13 @@ export default function GroupCreateModal(props: {
   const navigate = useNavigate();
 
   const handleEditDone = async (data: GroupEditData) => {
-    const { name, description, tags } = data;
+    const { name, description, tags, groupImage } = data;
     const response = await wrapApiResponse(
       API_CLIENT.groupController.createGroup({
-        // TODO: Add group image
         name,
         description,
         tags,
+        groupImage,
       })
     );
 
@@ -39,20 +39,20 @@ export default function GroupCreateModal(props: {
   };
 
   return (
-    <Modal open={open} onClose={onClose}>
-      <Box
-        sx={{
-          width: "100vw",
-          height: "100vh",
-          display: "flex",
-          justifyContent: "center",
-          alignItems: "center",
-        }}
-      >
-        <Container sx={{ height: "65vh" }}>
-          <GroupEditForm onEditDone={handleEditDone} onCancel={onClose} />
-        </Container>
-      </Box>
+    <Modal
+      open={open}
+      onClose={onClose}
+      sx={{
+        width: "100vw",
+        height: "100vh",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
+      <Container sx={{ height: "65vh" }}>
+        <GroupEditForm onEditDone={handleEditDone} onCancel={onClose} />
+      </Container>
     </Modal>
   );
 }

--- a/client/src/component/groupCreate/GroupEditForm.tsx
+++ b/client/src/component/groupCreate/GroupEditForm.tsx
@@ -1,8 +1,11 @@
 import { Add, Delete } from "@mui/icons-material";
 import {
   Button,
+  CardActionArea,
+  CardMedia,
   Chip,
   Grid,
+  Icon,
   IconButton,
   InputAdornment,
   OutlinedInput,
@@ -10,12 +13,13 @@ import {
   Stack,
   TextField,
 } from "@mui/material";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 export type GroupEditData = {
   name: string;
   description: string;
   tags: string[];
+  groupImage?: File;
 };
 
 export default function GroupEditForm(props: {
@@ -28,12 +32,14 @@ export default function GroupEditForm(props: {
   const [description, setDescription] = useState("");
   const [tag, setTag] = useState("");
   const [tags, setTags] = useState<string[]>([]);
+  const [groupImage, setGroupImage] = useState<File | undefined>(undefined);
 
   const handleEditDoneButtonClicked = () => {
     onEditDone({
       name,
       description,
       tags,
+      groupImage,
     });
   };
 
@@ -53,16 +59,58 @@ export default function GroupEditForm(props: {
     setTags((prev) => prev.filter((t) => t !== tag));
   };
 
+  const groupImagePreviewUrl = useMemo(() => {
+    if (!groupImage) {
+      return "";
+    }
+    return URL.createObjectURL(groupImage);
+  }, [groupImage]);
+
   return (
     <Paper sx={{ width: "100%", height: "100%", padding: 2 }}>
-      <Stack spacing={2} sx={{ height: "100%", overflowY: "auto" }}>
+      <Stack spacing={2} sx={{ height: "100%", overflowY: "auto", padding: 2 }}>
+        <CardActionArea
+          onClick={() => {
+            const fileInput = document.createElement("input");
+            fileInput.type = "file";
+            fileInput.accept = "image/*";
+            fileInput.onchange = (e) => {
+              const file = (e.target as HTMLInputElement).files?.[0];
+              if (file) {
+                setGroupImage(file);
+              }
+            };
+            fileInput.click();
+          }}
+          sx={{
+            display: "flex",
+            textAlign: "center",
+            justifyContent: "center",
+          }}
+        >
+          {groupImage ? (
+            <CardMedia
+              image={groupImagePreviewUrl}
+              sx={{
+                width: 256,
+                height: 256,
+              }}
+            />
+          ) : (
+            <Icon sx={{ width: 256, height: 256, lineHeight: "256px" }}>
+              <Add fontSize="large" />
+            </Icon>
+          )}
+        </CardActionArea>
         <TextField
+          placeholder="모임 이름"
           variant="outlined"
           fullWidth
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
         <TextField
+          placeholder="모임 설명"
           variant="outlined"
           multiline
           fullWidth

--- a/client/src/component/groupList.tsx
+++ b/client/src/component/groupList.tsx
@@ -14,6 +14,7 @@ import API_CLIENT, { wrapApiResponse } from "../api/api";
 import { JSX, PropsWithChildren, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import PageNavigation from "./PageNavigation";
+import { GroupInfo } from "../types/groups";
 const ITEM_HEIGHT = 384 - 20;
 
 export default function GroupList(props: {
@@ -29,7 +30,7 @@ export default function GroupList(props: {
 
   const pageSize = size === "small" ? 6 : 12;
 
-  const { data } = useQuery({
+  const { data: groups } = useQuery({
     queryKey: ["groupList", page, sort, pageSize],
     queryFn: async () => {
       const response = await wrapApiResponse(
@@ -42,12 +43,15 @@ export default function GroupList(props: {
 
       if (response.isSuccessful) {
         setTotalPages(response.data.totalPages!);
-        return response.data.content;
+        return response.data.content! as GroupInfo[];
       }
 
       throw new Error(response.errorMessage);
     },
-    initialData: new Array(pageSize).fill(undefined),
+    initialData: new Array(pageSize).fill(undefined) as (
+      | GroupInfo
+      | undefined
+    )[],
     placeholderData: keepPreviousData,
   });
 
@@ -68,7 +72,7 @@ export default function GroupList(props: {
           totalPages={totalPages}
         />
         <Grid container spacing={2}>
-          {data?.map((group, index) =>
+          {groups?.map((group, index) =>
             group ? (
               <ItemContainer key={group.groupId}>
                 <Card sx={{ height: ITEM_HEIGHT }} elevation={3}>
@@ -83,7 +87,7 @@ export default function GroupList(props: {
                     onClick={() => {
                       navigate({
                         to: "/groups/$groupId",
-                        params: { groupId: group.groupId.toString() },
+                        params: { groupId: group.groupId!.toString() },
                       });
                     }}
                   >
@@ -91,8 +95,9 @@ export default function GroupList(props: {
                     <CardMedia
                       height={192}
                       component={"img"}
-                      // TODO: Use group image
-                      image="https://picsum.photos/512/512"
+                      image={
+                        group.groupImageURL || "https://picsum.photos/192/192"
+                      }
                     />
                     <CardContent>
                       <Typography

--- a/client/src/routes/_pathlessLayout/admin/uploadBook.tsx
+++ b/client/src/routes/_pathlessLayout/admin/uploadBook.tsx
@@ -1,15 +1,21 @@
 import {
   Button,
   Card,
+  CardActionArea,
   CardActions,
   CardContent,
   CardHeader,
+  CardMedia,
+  Icon,
   InputLabel,
   TextField,
 } from "@mui/material";
 import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import API_CLIENT, { wrapApiResponse } from "../../../api/api";
+import { Add } from "@mui/icons-material";
+
+const MAX_DESCRIPTION_LENGTH = 255;
 
 export const Route = createFileRoute("/_pathlessLayout/admin/uploadBook")({
   component: RouteComponent,
@@ -20,6 +26,7 @@ function RouteComponent() {
   const [title, setTitle] = useState("");
   const [author, setAuthor] = useState("");
   const [description, setDescription] = useState("");
+  const [coverImageFile, setCoverImageFile] = useState<File | null>(null);
 
   const handleUploadBookButtonClicked = async () => {
     const inputElement = document.createElement("input");
@@ -38,20 +45,60 @@ function RouteComponent() {
           file,
           description,
           author,
+          coverImageFile: coverImageFile ?? undefined,
         })
       );
       if (response.isSuccessful) {
         setTitle("");
         setAuthor("");
         setDescription("");
+        setCoverImageFile(null);
       }
     };
     inputElement.click();
   };
 
+  const coverImageFilePreviewUrl = useMemo(() => {
+    if (!coverImageFile) return "";
+    return URL.createObjectURL(coverImageFile);
+  }, [coverImageFile]);
+
   return (
     <Card>
       <CardHeader title="Upload Book" />
+      <CardActionArea
+        onClick={() => {
+          const fileInput = document.createElement("input");
+          fileInput.type = "file";
+          fileInput.accept = "image/*";
+          fileInput.onchange = (e) => {
+            const file = (e.target as HTMLInputElement).files?.[0];
+            if (file) {
+              setCoverImageFile(file);
+            }
+          };
+          fileInput.click();
+        }}
+        sx={{
+          display: "flex",
+          textAlign: "center",
+          justifyContent: "center",
+        }}
+      >
+        {coverImageFile ? (
+          <CardMedia
+            image={coverImageFilePreviewUrl}
+            sx={{
+              width: 256,
+              height: 256,
+            }}
+          />
+        ) : (
+          <Icon sx={{ width: 256, height: 256, lineHeight: "256px" }}>
+            <Add fontSize="large" />
+          </Icon>
+        )}
+      </CardActionArea>
       <CardContent>
         <InputLabel>Title</InputLabel>
         <TextField
@@ -77,7 +124,16 @@ function RouteComponent() {
           placeholder="Description"
           multiline
           value={description}
-          onChange={(e) => setDescription(e.target.value)}
+          inputProps={{ maxLength: MAX_DESCRIPTION_LENGTH }}
+          onChange={(e) => {
+            const value = e.target.value;
+            if (value.length >= MAX_DESCRIPTION_LENGTH) {
+              setDescription(value.slice(0, MAX_DESCRIPTION_LENGTH));
+              return;
+            }
+            setDescription(value);
+          }}
+          helperText={`${description.length} / ${MAX_DESCRIPTION_LENGTH}`}
         />
       </CardContent>
       <CardActions>

--- a/client/src/routes/_pathlessLayout/books/index.tsx
+++ b/client/src/routes/_pathlessLayout/books/index.tsx
@@ -12,6 +12,7 @@ import {
   IconButton,
   InputAdornment,
   Paper,
+  Skeleton,
   Stack,
   Typography,
 } from "@mui/material";
@@ -87,37 +88,9 @@ function RouteComponent() {
             />
             <Divider />
             <Stack spacing={1}>
-              {books.map((book) => {
-                return (
-                  <Card
-                    elevation={3}
-                    key={book?.id}
-                    sx={{
-                      padding: 2,
-                    }}
-                  >
-                    <Stack spacing={1} direction={"row"}>
-                      <CardActionArea sx={{ width: 128, height: 160 }}>
-                        <CardMedia
-                          image="https://picsum.photos/512/512"
-                          sx={{ width: 128, height: 160 }}
-                        />
-                      </CardActionArea>
-                      <Stack flexGrow={1} spacing={1}>
-                        <CardActionArea>
-                          <Typography variant="h5">{book?.title}</Typography>
-                        </CardActionArea>
-                        <CardActionArea>
-                          <Typography variant="body2">
-                            {book?.author}
-                          </Typography>
-                        </CardActionArea>
-                        <Typography variant="body2">{book?.size} KB</Typography>
-                      </Stack>
-                    </Stack>
-                  </Card>
-                );
-              })}
+              {books.map((book) => (
+                <BookCard book={book} />
+              ))}
             </Stack>
             <Divider />
 
@@ -130,5 +103,49 @@ function RouteComponent() {
         </Paper>
       </Stack>
     </Container>
+  );
+}
+function BookCard(props: { book?: BookMetadata }) {
+  const { book } = props;
+  if (!book) {
+    return (
+      <Card elevation={3} sx={{ padding: 2 }}>
+        <Stack spacing={1} direction={"row"}>
+          <Skeleton variant="rectangular" width={128} height={160} />
+          <Stack flexGrow={1} spacing={1}>
+            <Skeleton variant="text" width="60%" height={32} />
+            <Skeleton variant="text" width="40%" height={24} />
+            <Skeleton variant="text" width="30%" height={20} />
+          </Stack>
+        </Stack>
+      </Card>
+    );
+  }
+  return (
+    <Card
+      elevation={3}
+      key={book.id}
+      sx={{
+        padding: 2,
+      }}
+    >
+      <Stack spacing={1} direction={"row"}>
+        <CardActionArea sx={{ width: 128, height: 160 }}>
+          <CardMedia
+            image={book.bookCoverImageURL || "https://picsum.photos/128/160"}
+            sx={{ width: 128, height: 160 }}
+          />
+        </CardActionArea>
+        <Stack flexGrow={1} spacing={1}>
+          <CardActionArea>
+            <Typography variant="h5">{book.title}</Typography>
+          </CardActionArea>
+          <CardActionArea>
+            <Typography variant="body2">{book.author}</Typography>
+          </CardActionArea>
+          <Typography variant="body2">{book.size} KB</Typography>
+        </Stack>
+      </Stack>
+    </Card>
   );
 }

--- a/client/src/routes/_pathlessLayout/groups/$groupId/index.tsx
+++ b/client/src/routes/_pathlessLayout/groups/$groupId/index.tsx
@@ -84,66 +84,72 @@ function RouteComponent() {
       <Stack spacing={4} sx={{ mb: 2 }}>
         <Paper sx={{ p: 2 }}>
           <Stack spacing={2}>
-            <Stack>
-              <Stack
-                direction={"row"}
-                spacing={2}
-                justifyContent={"space-between"}
-              >
-                <Typography variant="h3">
-                  {group ? group.name : <Skeleton variant="text" />}
-                </Typography>
-                <LinkIconButton
-                  to={"/groups/$groupId/manage"}
-                  params={{ groupId }}
-                  size="large"
-                  sx={{
-                    alignSelf: "center",
-                    justifySelf: "flex-end",
-                  }}
-                >
-                  <Settings />
-                </LinkIconButton>
+            <Stack direction={"row"} spacing={2}>
+              <Stack flexGrow={1}>
+                <Stack direction={"row"} spacing={2} flexGrow={1}>
+                  <Stack>
+                    {group ? (
+                      <CardMedia
+                        image={group.groupImageURL}
+                        sx={{ width: 256, height: 256 }}
+                      />
+                    ) : (
+                      <Skeleton
+                        variant="rectangular"
+                        width={256}
+                        height={256}
+                      />
+                    )}
+                  </Stack>
+                  <Stack sx={{ flexGrow: 1 }}>
+                    <Stack direction={"row"} spacing={1}>
+                      <Typography variant="h3" flexGrow={1}>
+                        {group ? group.name : <Skeleton variant="text" />}
+                      </Typography>
+                      <Typography
+                        variant="body2"
+                        color="textSecondary"
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                        }}
+                      >
+                        <Icon>
+                          <People />
+                        </Icon>
+                        {group ? group.memberCount : <Skeleton />}
+                      </Typography>
+                      <LinkIconButton
+                        to={"/groups/$groupId/manage"}
+                        params={{ groupId }}
+                        size="large"
+                        sx={{
+                          alignSelf: "center",
+                          justifySelf: "flex-end",
+                        }}
+                      >
+                        <Settings />
+                      </LinkIconButton>
+                    </Stack>
+                    <Typography variant="body1" flexGrow={1}>
+                      {group ? group.description : <Skeleton />}
+                    </Typography>
+                    <Button
+                      onClick={handleJoinGroup}
+                      variant="contained"
+                      disabled={joinGroupRequested}
+                      sx={{
+                        justifySelf: "flex-end",
+                        alignSelf: "flex-end",
+                        width: "fit-content",
+                      }}
+                    >
+                      {joinGroupRequested ? "가입 대기중" : "가입하기"}
+                    </Button>
+                  </Stack>
+                </Stack>
               </Stack>
-              <Box
-                sx={{
-                  justifySelf: "flex-end",
-                  alignSelf: "flex-end",
-                  display: "flex",
-                  flexDirection: "row",
-                }}
-              >
-                <Typography
-                  variant="body2"
-                  color="textSecondary"
-                  sx={{
-                    display: "flex",
-                    alignItems: "center",
-                  }}
-                >
-                  <Icon>
-                    <People />
-                  </Icon>
-                  {group ? group.memberCount : <Skeleton />}
-                </Typography>
-              </Box>
             </Stack>
-            <Button
-              onClick={handleJoinGroup}
-              variant="contained"
-              disabled={joinGroupRequested}
-              sx={{
-                justifySelf: "flex-end",
-                alignSelf: "flex-end",
-                width: "fit-content",
-              }}
-            >
-              {joinGroupRequested ? "가입 대기중" : "가입하기"}
-            </Button>
-            <Divider />
-            <Typography variant="body1" sx={{ mt: 2 }}>
-              {group ? group.description : <Skeleton />}
-            </Typography>
             <Divider />
             <Grid container spacing={1}>
               {group ? (

--- a/client/src/types/book.ts
+++ b/client/src/types/book.ts
@@ -1,6 +1,7 @@
 export type BookMetadata = {
   id: number;
   title: string;
+  bookCoverImageURL: string;
   author: string;
   description: string | null;
   size: number;

--- a/client/src/types/groups.ts
+++ b/client/src/types/groups.ts
@@ -3,5 +3,6 @@ export type GroupInfo = {
   name: string;
   description: string;
   tags: string[];
+  groupImageURL: string;
   memberCount: number;
 };


### PR DESCRIPTION
## ✨ 작업 개요
그룹, 책 이미지 지원

## ✅ 작업 내용
- 그룹 생성 시 이미지 업로드
- 그룹 카드에 그룹 이미지 표시
- 책 업로드 시 이미지 업로드
- 책 카드에 책 이미지 표시

## 📎 관련 이슈
Closes #174 

## 🧪 테스트 방법

## 💬 기타
