### PR TITLE
[TASK 4-7-1][BE] 토론 CRUD

### DIFF
--- a/chaekit-spring/src/main/java/qwerty/chaekit/controller/MainController.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/controller/MainController.java
@@ -10,7 +10,6 @@ import qwerty.chaekit.global.response.ApiSuccessResponse;
 public class MainController {
     @GetMapping("/api")
     public ApiSuccessResponse<String> mainApi() {
-        log.info("Health check API called");
         return ApiSuccessResponse.of("Welcome to Chaekit");
     }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/controller/group/DiscussionController.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/controller/group/DiscussionController.java
@@ -8,10 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
-import qwerty.chaekit.dto.group.activity.discussion.DiscussionDetailResponse;
-import qwerty.chaekit.dto.group.activity.discussion.DiscussionFetchResponse;
-import qwerty.chaekit.dto.group.activity.discussion.DiscussionPatchRequest;
-import qwerty.chaekit.dto.group.activity.discussion.DiscussionPostRequest;
+import qwerty.chaekit.dto.group.activity.discussion.*;
 import qwerty.chaekit.dto.page.PageResponse;
 import qwerty.chaekit.global.security.resolver.Login;
 import qwerty.chaekit.global.security.resolver.UserToken;
@@ -85,5 +82,49 @@ public class DiscussionController {
             @PathVariable Long discussionId
     ) {
         discussionService.deleteDiscussion(userToken, discussionId);
+    }
+
+    @Operation(
+            summary = "토론 댓글 단건 조회",
+            description = "토론 댓글을 조회합니다."
+    )
+    @GetMapping("/discussions/comments/{commentId}")
+    public DiscussionCommentFetchResponse getComment(@PathVariable Long commentId) {
+        return discussionService.getComment(commentId);
+    }
+
+    @Operation(
+            summary = "토론 댓글 작성",
+            description = "토론 게시글에 토론 댓글을 작성합니다."
+    )
+    @PostMapping("/discussions/{discussionId}/comments")
+    public DiscussionCommentFetchResponse addComment(
+            @PathVariable Long discussionId,
+            @RequestBody @Valid DiscussionCommentPostRequest request,
+            @Login UserToken userToken
+    ) {
+        return discussionService.addComment(discussionId, request, userToken);
+    }
+
+    @Operation(
+            summary = "토론 댓글 수정",
+            description = "토론 댓글의 내용을 수정합니다."
+    )
+    @PatchMapping("/discussions/comments/{commentId}")
+    public DiscussionCommentFetchResponse updateComment(
+            @PathVariable Long commentId,
+            @RequestBody @Valid DiscussionCommentPatchRequest request,
+            @Login UserToken userToken
+    ) {
+        return discussionService.updateComment(commentId, request, userToken);
+    }
+
+    @Operation(
+            summary = "토론 댓글 삭제",
+            description = "토론 댓글을 삭제합니다."
+    )
+    @DeleteMapping("/discussions/comments/{commentId}")
+    public void deleteComment(@PathVariable Long commentId, @Login UserToken userToken) {
+        discussionService.deleteComment(commentId, userToken);
     }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/controller/group/DiscussionController.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/controller/group/DiscussionController.java
@@ -1,0 +1,73 @@
+package qwerty.chaekit.controller.group;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+import qwerty.chaekit.dto.group.activity.discussion.DiscussionDetailResponse;
+import qwerty.chaekit.dto.group.activity.discussion.DiscussionFetchResponse;
+import qwerty.chaekit.dto.group.activity.discussion.DiscussionPostRequest;
+import qwerty.chaekit.dto.page.PageResponse;
+import qwerty.chaekit.global.security.resolver.Login;
+import qwerty.chaekit.global.security.resolver.UserToken;
+
+@RestController
+@RequestMapping("/api/activities/{activityId}/discussions")
+@Tag(name = "토론", description = "토론 관련 API")
+public class DiscussionController {
+    @Operation(
+            summary = "토론 목록 조회",
+            description = "특정 활동에 해당하는 토론 목록을 조회합니다."
+    )
+    @GetMapping
+    public PageResponse<DiscussionFetchResponse> getDiscussions(
+            @ParameterObject Pageable pageable,
+            @PathVariable Long activityId
+    ) {
+
+        return null;
+    }
+
+    @Operation(
+            summary = "토론 생성",
+            description = "특정 활동에 새로운 토론을 생성합니다."
+    )
+    @PostMapping
+    public DiscussionFetchResponse createDiscussion(
+            @Login UserToken userToken,
+            @PathVariable Long activityId,
+            @RequestBody DiscussionPostRequest discussion
+    ) {
+
+        return null;
+    }
+
+    @Operation(
+            summary = "토론 상세 조회",
+            description = "특정 토론에 대해 댓글 등을 포함한 상세 정보를 조회합니다."
+    )
+    @GetMapping("/{discussionId}")
+    public DiscussionDetailResponse getDiscussion(
+            @PathVariable Long activityId,
+            @PathVariable Long discussionId
+    ) {
+
+        return null;
+    }
+
+    @Operation(
+            summary = "토론 수정",
+            description = "토론 제목, 내용, 찬반 여부를 수정합니다."
+    )
+    @PatchMapping("/{discussionId}")
+    public DiscussionFetchResponse updateDiscussion(
+            @Login UserToken userToken,
+            @PathVariable Long activityId,
+            @PathVariable Long discussionId,
+            @RequestBody DiscussionPostRequest discussion
+    ) {
+
+        return null;
+    }
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/controller/group/DiscussionController.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/controller/group/DiscussionController.java
@@ -1,73 +1,89 @@
 package qwerty.chaekit.controller.group;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 import qwerty.chaekit.dto.group.activity.discussion.DiscussionDetailResponse;
 import qwerty.chaekit.dto.group.activity.discussion.DiscussionFetchResponse;
+import qwerty.chaekit.dto.group.activity.discussion.DiscussionPatchRequest;
 import qwerty.chaekit.dto.group.activity.discussion.DiscussionPostRequest;
 import qwerty.chaekit.dto.page.PageResponse;
 import qwerty.chaekit.global.security.resolver.Login;
 import qwerty.chaekit.global.security.resolver.UserToken;
+import qwerty.chaekit.service.group.DiscussionService;
 
 @RestController
-@RequestMapping("/api/activities/{activityId}/discussions")
+@RequestMapping("/api")
+@RequiredArgsConstructor
 @Tag(name = "토론", description = "토론 관련 API")
 public class DiscussionController {
+    private final DiscussionService discussionService;
+
     @Operation(
             summary = "토론 목록 조회",
             description = "특정 활동에 해당하는 토론 목록을 조회합니다."
     )
-    @GetMapping
+    @GetMapping("/activities/{activityId}/discussions")
     public PageResponse<DiscussionFetchResponse> getDiscussions(
+            @Parameter(hidden = true) @Login(required = false) UserToken userToken,
             @ParameterObject Pageable pageable,
             @PathVariable Long activityId
     ) {
-
-        return null;
+        return discussionService.getDiscussions(userToken, pageable, activityId);
     }
 
     @Operation(
             summary = "토론 생성",
             description = "특정 활동에 새로운 토론을 생성합니다."
     )
-    @PostMapping
+    @PostMapping("/activities/{activityId}/discussions")
     public DiscussionFetchResponse createDiscussion(
-            @Login UserToken userToken,
+            @Parameter(hidden = true) @Login UserToken userToken,
             @PathVariable Long activityId,
-            @RequestBody DiscussionPostRequest discussion
+            @RequestBody @Valid DiscussionPostRequest request
     ) {
-
-        return null;
+        return discussionService.createDiscussion(userToken, activityId, request);
     }
 
     @Operation(
             summary = "토론 상세 조회",
             description = "특정 토론에 대해 댓글 등을 포함한 상세 정보를 조회합니다."
     )
-    @GetMapping("/{discussionId}")
+    @GetMapping("/discussions/{discussionId}")
     public DiscussionDetailResponse getDiscussion(
-            @PathVariable Long activityId,
+            @Parameter(hidden = true) @Login UserToken userToken,
             @PathVariable Long discussionId
     ) {
-
-        return null;
+        return discussionService.getDiscussionDetail(userToken, discussionId);
     }
 
     @Operation(
             summary = "토론 수정",
             description = "토론 제목, 내용, 찬반 여부를 수정합니다."
     )
-    @PatchMapping("/{discussionId}")
+    @PatchMapping("/discussions/{discussionId}")
     public DiscussionFetchResponse updateDiscussion(
-            @Login UserToken userToken,
-            @PathVariable Long activityId,
+            @Parameter(hidden = true) @Login UserToken userToken,
             @PathVariable Long discussionId,
-            @RequestBody DiscussionPostRequest discussion
+            @RequestBody @Valid DiscussionPatchRequest request
     ) {
+        return discussionService.updateDiscussion(userToken, discussionId, request);
+    }
 
-        return null;
+    @Operation(
+            summary = "토론 삭제",
+            description = "토론을 삭제합니다."
+    )
+    @DeleteMapping("/discussions/{discussionId}")
+    public void deleteDiscussion(
+            @Parameter(hidden = true) @Login UserToken userToken,
+            @PathVariable Long discussionId
+    ) {
+        discussionService.deleteDiscussion(userToken, discussionId);
     }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/Discussion.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/Discussion.java
@@ -8,6 +8,9 @@ import qwerty.chaekit.domain.BaseEntity;
 import qwerty.chaekit.domain.group.activity.Activity;
 import qwerty.chaekit.domain.member.user.UserProfile;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Table(name = "discussion")
@@ -30,4 +33,10 @@ public class Discussion extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "author_id")
     private UserProfile author;
+
+    @Column(nullable = false)
+    private boolean isDebate = false;
+
+    @OneToMany(mappedBy = "discussion")
+    private List<DiscussionComment> comments = new ArrayList<>();
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/Discussion.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/Discussion.java
@@ -2,6 +2,7 @@ package qwerty.chaekit.domain.group.activity.discussion;
 
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import qwerty.chaekit.domain.BaseEntity;
@@ -38,5 +39,27 @@ public class Discussion extends BaseEntity {
     private boolean isDebate = false;
 
     @OneToMany(mappedBy = "discussion")
-    private List<DiscussionComment> comments = new ArrayList<>();
+    private final List<DiscussionComment> comments = new ArrayList<>();
+
+    @Builder
+    public Discussion(Long id, Activity activity, String title, String content, UserProfile author, boolean isDebate) {
+        this.id = id;
+        this.activity = activity;
+        this.title = title;
+        this.content = content;
+        this.author = author;
+        this.isDebate = isDebate;
+    }
+
+    public void update(String title, String content, Boolean debate) {
+        if(title != null) {
+            this.title = title;
+        }
+        if(content != null) {
+            this.content = content;
+        }
+        if(debate != null) {
+            this.isDebate = debate;
+        }
+    }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/DiscussionComment.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/DiscussionComment.java
@@ -2,10 +2,7 @@ package qwerty.chaekit.domain.group.activity.discussion;
 
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.hibernate.annotations.BatchSize;
 import qwerty.chaekit.domain.BaseEntity;
 import qwerty.chaekit.domain.member.user.UserProfile;
@@ -33,11 +30,11 @@ public class DiscussionComment extends BaseEntity {
     @Column(nullable = false)
     private String content;
 
-    @Column(nullable = false)
-    private boolean isDeleted = false;
+    @Column(name = "is_edited", nullable = false)
+    private boolean edited = false;
 
-    @Column(nullable = false)
-    private boolean isEdited = false;
+    @Column(name = "is_deleted", nullable = false)
+    private boolean deleted = false;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
@@ -50,13 +47,24 @@ public class DiscussionComment extends BaseEntity {
 
     @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
     @BatchSize(size = 50)
-    private List<DiscussionComment> replies = new ArrayList<>();
+    private final List<DiscussionComment> replies = new ArrayList<>();
 
-    public void addReply(DiscussionComment reply) {
-        if (parent != null) {
-            throw new IllegalStateException("Cannot add a reply to a reply.");
-        }
-        replies.add(reply);
-        reply.setParent(this);
+    @Builder
+    public DiscussionComment(UserProfile author, Discussion discussion, String content, DiscussionStance stance, DiscussionComment parent) {
+        this.author = author;
+        this.discussion = discussion;
+        this.content = content;
+        this.stance = stance;
+        this.parent = parent;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+        this.edited = true;
+    }
+
+    public void softDelete() {
+        this.content = "삭제된 댓글입니다.";
+        this.deleted = true;
     }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/DiscussionComment.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/DiscussionComment.java
@@ -5,8 +5,13 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
 import qwerty.chaekit.domain.BaseEntity;
 import qwerty.chaekit.domain.member.user.UserProfile;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -27,4 +32,31 @@ public class DiscussionComment extends BaseEntity {
 
     @Column(nullable = false)
     private String content;
+
+    @Column(nullable = false)
+    private boolean isDeleted = false;
+
+    @Column(nullable = false)
+    private boolean isEdited = false;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private DiscussionStance stance = DiscussionStance.NEUTRAL;
+
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private DiscussionComment parent = null;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
+    @BatchSize(size = 50)
+    private List<DiscussionComment> replies = new ArrayList<>();
+
+    public void addReply(DiscussionComment reply) {
+        if (parent != null) {
+            throw new IllegalStateException("Cannot add a reply to a reply.");
+        }
+        replies.add(reply);
+        reply.setParent(this);
+    }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/DiscussionComment.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/DiscussionComment.java
@@ -50,7 +50,8 @@ public class DiscussionComment extends BaseEntity {
     private final List<DiscussionComment> replies = new ArrayList<>();
 
     @Builder
-    public DiscussionComment(UserProfile author, Discussion discussion, String content, DiscussionStance stance, DiscussionComment parent) {
+    public DiscussionComment(Long id, UserProfile author, Discussion discussion, String content, DiscussionStance stance, DiscussionComment parent) {
+        this.id = id;
         this.author = author;
         this.discussion = discussion;
         this.content = content;

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/DiscussionStance.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/DiscussionStance.java
@@ -1,0 +1,5 @@
+package qwerty.chaekit.domain.group.activity.discussion;
+
+public enum DiscussionStance {
+    AGREE, DISAGREE, NEUTRAL;
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/comment/DiscussionCommentJpaRepository.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/comment/DiscussionCommentJpaRepository.java
@@ -1,0 +1,23 @@
+package qwerty.chaekit.domain.group.activity.discussion.comment;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import qwerty.chaekit.domain.group.activity.discussion.DiscussionComment;
+
+import java.util.Optional;
+
+public interface DiscussionCommentJpaRepository extends JpaRepository<DiscussionComment, Long> {
+    Long countByDiscussion_Id(Long discussionId);
+    @Query("SELECT c FROM DiscussionComment c JOIN FETCH c.author WHERE c.id = :id")
+    Optional<DiscussionComment> findByIdWithAuthor(Long id);
+
+    Long countByParent_Id(Long parentId);
+
+    @Query("""
+           SELECT c FROM DiscussionComment c
+           LEFT JOIN FETCH c.replies
+           LEFT JOIN FETCH c.parent
+           WHERE c.id = :id
+           """)
+    Optional<DiscussionComment> findByIdWithRepliesAndParent(Long id);
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/comment/DiscussionCommentRepository.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/comment/DiscussionCommentRepository.java
@@ -1,0 +1,24 @@
+package qwerty.chaekit.domain.group.activity.discussion.comment;
+
+import qwerty.chaekit.domain.group.activity.discussion.DiscussionComment;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public interface DiscussionCommentRepository {
+    DiscussionComment getReferenceById(Long id);
+    boolean existsById(Long id);
+    Optional<DiscussionComment> findById(Long id);
+    Optional<DiscussionComment> findByIdWithAuthor(Long id);
+    Optional<DiscussionComment> findByIdWithParent(Long id);
+
+    DiscussionComment save(DiscussionComment discussionComment);
+    void delete(DiscussionComment discussionComment);
+
+
+    Long countCommentsByDiscussionId(Long discussionId);
+    Map<Long, Long> countCommentsByDiscussionIds(List<Long> discussionIds);
+    Long countByParentId(Long parentId);
+
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/comment/DiscussionCommentRepositoryImpl.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/comment/DiscussionCommentRepositoryImpl.java
@@ -1,0 +1,80 @@
+package qwerty.chaekit.domain.group.activity.discussion.comment;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import qwerty.chaekit.domain.group.activity.discussion.DiscussionComment;
+import qwerty.chaekit.domain.group.activity.discussion.QDiscussionComment;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class DiscussionCommentRepositoryImpl implements DiscussionCommentRepository {
+    private final DiscussionCommentJpaRepository commentJpaRepository;
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public DiscussionComment getReferenceById(Long id) {
+        return commentJpaRepository.getReferenceById(id);
+    }
+
+    @Override
+    public boolean existsById(Long id) {
+        return commentJpaRepository.existsById(id);
+    }
+
+    @Override
+    public Optional<DiscussionComment> findById(Long id) {
+        return commentJpaRepository.findById(id);
+    }
+
+    @Override
+    public Optional<DiscussionComment> findByIdWithAuthor(Long id) {
+        return commentJpaRepository.findByIdWithAuthor(id);
+    }
+
+    @Override
+    public DiscussionComment save(DiscussionComment discussionComment) {
+        return commentJpaRepository.save(discussionComment);
+    }
+
+    @Override
+    public void delete(DiscussionComment discussionComment) {
+        commentJpaRepository.delete(discussionComment);
+    }
+
+    @Override
+    public Long countCommentsByDiscussionId(Long discussionId) {
+        return commentJpaRepository.countByDiscussion_Id(discussionId);
+    }
+
+    @Override
+    public Map<Long, Long> countCommentsByDiscussionIds(List<Long> discussionIds) {
+        QDiscussionComment comment = QDiscussionComment.discussionComment;
+        return queryFactory
+                .select(comment.discussion.id, comment.count())
+                .from(comment)
+                .where(comment.discussion.id.in(discussionIds))
+                .groupBy(comment.discussion.id)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(comment.discussion.id),
+                        tuple -> Optional.ofNullable(tuple.get(comment.count())).orElse(0L)
+                ));
+    }
+
+    @Override
+    public Long countByParentId(Long parentId) {
+        return commentJpaRepository.countByParent_Id(parentId);
+    }
+
+    @Override
+    public Optional<DiscussionComment> findByIdWithParent(Long id) {
+        return commentJpaRepository.findByIdWithRepliesAndParent(id);
+    }
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/repository/DiscussionCommentJpaRepository.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/repository/DiscussionCommentJpaRepository.java
@@ -1,8 +1,0 @@
-package qwerty.chaekit.domain.group.activity.discussion.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import qwerty.chaekit.domain.group.activity.discussion.DiscussionComment;
-
-public interface DiscussionCommentJpaRepository extends JpaRepository<DiscussionComment, Long> {
-    Long countByDiscussion_Id(Long discussionId);
-}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/repository/DiscussionCommentJpaRepository.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/repository/DiscussionCommentJpaRepository.java
@@ -1,0 +1,8 @@
+package qwerty.chaekit.domain.group.activity.discussion.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import qwerty.chaekit.domain.group.activity.discussion.DiscussionComment;
+
+public interface DiscussionCommentJpaRepository extends JpaRepository<DiscussionComment, Long> {
+    Long countByDiscussion_Id(Long discussionId);
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/repository/DiscussionJpaRepository.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/repository/DiscussionJpaRepository.java
@@ -1,0 +1,17 @@
+package qwerty.chaekit.domain.group.activity.discussion.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import qwerty.chaekit.domain.group.activity.discussion.Discussion;
+
+import java.util.Optional;
+
+
+public interface DiscussionJpaRepository extends JpaRepository<Discussion, Long> {
+    @Query("SELECT d FROM Discussion d JOIN FETCH d.author WHERE d.activity.id = :activityId")
+    Page<Discussion> findByActivity_Id(Long activityId, Pageable pageable);
+    @Query("SELECT d FROM Discussion d JOIN FETCH d.author LEFT JOIN FETCH d.comments WHERE d.id = :id")
+    Optional<Discussion> findByIdWithAuthorAndComments(Long id);
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/repository/DiscussionRepository.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/repository/DiscussionRepository.java
@@ -1,0 +1,19 @@
+package qwerty.chaekit.domain.group.activity.discussion.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import qwerty.chaekit.domain.group.activity.discussion.Discussion;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public interface DiscussionRepository {
+    Page<Discussion> findByActivityId(Long activityId, Pageable pageable);
+    Map<Long, Long> countCommentsByDiscussionIds(List<Long> discussionIds);
+    Optional<Discussion> findById(Long id);
+    Discussion save(Discussion discussion);
+    Long countCommentsByDiscussionId(Long discussionId);
+    Optional<Discussion> findByIdWithAuthorAndComments(Long id);
+    void delete(Discussion discussion);
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/repository/DiscussionRepository.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/repository/DiscussionRepository.java
@@ -4,16 +4,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import qwerty.chaekit.domain.group.activity.discussion.Discussion;
 
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 public interface DiscussionRepository {
-    Page<Discussion> findByActivityId(Long activityId, Pageable pageable);
-    Map<Long, Long> countCommentsByDiscussionIds(List<Long> discussionIds);
+    Discussion getReferenceById(Long id);
+    boolean existsById(Long id);
     Optional<Discussion> findById(Long id);
-    Discussion save(Discussion discussion);
-    Long countCommentsByDiscussionId(Long discussionId);
+    Page<Discussion> findByActivityId(Long activityId, Pageable pageable);
     Optional<Discussion> findByIdWithAuthorAndComments(Long id);
+    Discussion save(Discussion discussion);
     void delete(Discussion discussion);
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/repository/DiscussionRepositoryImpl.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/repository/DiscussionRepositoryImpl.java
@@ -1,0 +1,68 @@
+package qwerty.chaekit.domain.group.activity.discussion.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import qwerty.chaekit.domain.group.activity.discussion.Discussion;
+import qwerty.chaekit.domain.group.activity.discussion.QDiscussionComment;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class DiscussionRepositoryImpl implements DiscussionRepository {
+    private final DiscussionJpaRepository jpaRepository;
+    private final DiscussionCommentJpaRepository commentJpaRepository;
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Discussion> findById(Long id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public Page<Discussion> findByActivityId(Long activityId, Pageable pageable) {
+        return jpaRepository.findByActivity_Id(activityId, pageable);
+    }
+
+    @Override
+    public Long countCommentsByDiscussionId(Long discussionId) {
+        return commentJpaRepository.countByDiscussion_Id(discussionId);
+    }
+
+    @Override
+    public Optional<Discussion> findByIdWithAuthorAndComments(Long id) {
+        return jpaRepository.findByIdWithAuthorAndComments(id);
+    }
+
+    @Override
+    public Discussion save(Discussion discussion) {
+        return jpaRepository.save(discussion);
+    }
+
+    @Override
+    public void delete(Discussion discussion) {
+        jpaRepository.delete(discussion);
+    }
+
+    @Override
+    public Map<Long, Long> countCommentsByDiscussionIds(List<Long> discussionIds) {
+        QDiscussionComment comment = QDiscussionComment.discussionComment;
+        return queryFactory
+                .select(comment.discussion.id, comment.count())
+                .from(comment)
+                .where(comment.discussion.id.in(discussionIds))
+                .groupBy(comment.discussion.id)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(comment.discussion.id),
+                        tuple -> Optional.ofNullable(tuple.get(comment.count())).orElse(0L)
+                ));
+    }
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/repository/DiscussionRepositoryImpl.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/discussion/repository/DiscussionRepositoryImpl.java
@@ -1,24 +1,27 @@
 package qwerty.chaekit.domain.group.activity.discussion.repository;
 
-import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import qwerty.chaekit.domain.group.activity.discussion.Discussion;
-import qwerty.chaekit.domain.group.activity.discussion.QDiscussionComment;
 
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
 public class DiscussionRepositoryImpl implements DiscussionRepository {
     private final DiscussionJpaRepository jpaRepository;
-    private final DiscussionCommentJpaRepository commentJpaRepository;
-    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Discussion getReferenceById(Long id) {
+        return jpaRepository.getReferenceById(id);
+    }
+
+    @Override
+    public boolean existsById(Long id) {
+        return jpaRepository.existsById(id);
+    }
 
     @Override
     public Optional<Discussion> findById(Long id) {
@@ -28,11 +31,6 @@ public class DiscussionRepositoryImpl implements DiscussionRepository {
     @Override
     public Page<Discussion> findByActivityId(Long activityId, Pageable pageable) {
         return jpaRepository.findByActivity_Id(activityId, pageable);
-    }
-
-    @Override
-    public Long countCommentsByDiscussionId(Long discussionId) {
-        return commentJpaRepository.countByDiscussion_Id(discussionId);
     }
 
     @Override
@@ -50,19 +48,4 @@ public class DiscussionRepositoryImpl implements DiscussionRepository {
         jpaRepository.delete(discussion);
     }
 
-    @Override
-    public Map<Long, Long> countCommentsByDiscussionIds(List<Long> discussionIds) {
-        QDiscussionComment comment = QDiscussionComment.discussionComment;
-        return queryFactory
-                .select(comment.discussion.id, comment.count())
-                .from(comment)
-                .where(comment.discussion.id.in(discussionIds))
-                .groupBy(comment.discussion.id)
-                .fetch()
-                .stream()
-                .collect(Collectors.toMap(
-                        tuple -> tuple.get(comment.discussion.id),
-                        tuple -> Optional.ofNullable(tuple.get(comment.count())).orElse(0L)
-                ));
-    }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/member/user/UserProfile.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/member/user/UserProfile.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import qwerty.chaekit.domain.BaseEntity;
 import qwerty.chaekit.domain.member.Member;
 
@@ -12,6 +13,7 @@ import qwerty.chaekit.domain.member.Member;
 @Getter
 @Table(name = "user_profile")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@BatchSize(size = 50)
 public class UserProfile extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionCommentFetchResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionCommentFetchResponse.java
@@ -1,0 +1,18 @@
+package qwerty.chaekit.dto.group.activity.discussion;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record DiscussionCommentFetchResponse(
+        Long commentId,
+        Long authorId,
+        String authorName,
+        String authorProfileImageURL,
+        String content,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        boolean edited,
+        String stance,
+        Long parentId,
+        List<DiscussionCommentFetchResponse> replies
+) { }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionCommentFetchResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionCommentFetchResponse.java
@@ -1,8 +1,13 @@
 package qwerty.chaekit.dto.group.activity.discussion;
 
+import lombok.Builder;
+import qwerty.chaekit.domain.group.activity.discussion.DiscussionStance;
+import qwerty.chaekit.domain.group.activity.discussion.DiscussionComment;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Builder
 public record DiscussionCommentFetchResponse(
         Long commentId,
         Long authorId,
@@ -10,9 +15,9 @@ public record DiscussionCommentFetchResponse(
         String authorProfileImageURL,
         String content,
         LocalDateTime createdAt,
-        LocalDateTime updatedAt,
-        boolean edited,
-        String stance,
+        LocalDateTime modifiedAt,
+        boolean isEdited,
+        DiscussionStance stance,
         Long parentId,
         List<DiscussionCommentFetchResponse> replies
 ) { }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionCommentFetchResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionCommentFetchResponse.java
@@ -2,7 +2,6 @@ package qwerty.chaekit.dto.group.activity.discussion;
 
 import lombok.Builder;
 import qwerty.chaekit.domain.group.activity.discussion.DiscussionStance;
-import qwerty.chaekit.domain.group.activity.discussion.DiscussionComment;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,6 +16,7 @@ public record DiscussionCommentFetchResponse(
         LocalDateTime createdAt,
         LocalDateTime modifiedAt,
         boolean isEdited,
+        boolean isDeleted,
         DiscussionStance stance,
         Long parentId,
         List<DiscussionCommentFetchResponse> replies

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionCommentPatchRequest.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionCommentPatchRequest.java
@@ -1,0 +1,6 @@
+package qwerty.chaekit.dto.group.activity.discussion;
+
+public record DiscussionCommentPatchRequest(
+        String content
+) {
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionCommentPostRequest.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionCommentPostRequest.java
@@ -1,0 +1,14 @@
+package qwerty.chaekit.dto.group.activity.discussion;
+
+
+import jakarta.validation.constraints.NotNull;
+import qwerty.chaekit.domain.group.activity.discussion.DiscussionStance;
+
+public record DiscussionCommentPostRequest(
+        Long parentId,
+        @NotNull
+        String content,
+        @NotNull
+        DiscussionStance stance
+) {
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionDetailResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionDetailResponse.java
@@ -1,17 +1,22 @@
 package qwerty.chaekit.dto.group.activity.discussion;
 
+import lombok.Builder;
+
+import java.time.LocalDateTime;
 import java.util.List;
 
+@Builder
 public record DiscussionDetailResponse(
         Long discussionId,
-        Long groupId,
         Long activityId,
         String title,
         String content,
         Long authorId,
-        String createdAt,
-        String updatedAt,
-        int commentCount,
+        String authorName,
+        String authorProfileImage,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt,
+        Long commentCount,
         boolean isDebate,
         boolean isAuthor,
         List<DiscussionCommentFetchResponse> comments

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionDetailResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionDetailResponse.java
@@ -1,0 +1,19 @@
+package qwerty.chaekit.dto.group.activity.discussion;
+
+import java.util.List;
+
+public record DiscussionDetailResponse(
+        Long discussionId,
+        Long groupId,
+        Long activityId,
+        String title,
+        String content,
+        Long authorId,
+        String createdAt,
+        String updatedAt,
+        int commentCount,
+        boolean isDebate,
+        boolean isAuthor,
+        List<DiscussionCommentFetchResponse> comments
+) {
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionFetchResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionFetchResponse.java
@@ -1,0 +1,16 @@
+package qwerty.chaekit.dto.group.activity.discussion;
+
+public record DiscussionFetchResponse(
+        Long discussionId,
+        Long groupId,
+        Long activityId,
+        String title,
+        String content,
+        Long authorId,
+        String createdAt,
+        String updatedAt,
+        int commentCount,
+        boolean isDebate,
+        boolean isAuthor
+) {
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionFetchResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionFetchResponse.java
@@ -1,15 +1,21 @@
 package qwerty.chaekit.dto.group.activity.discussion;
 
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
 public record DiscussionFetchResponse(
         Long discussionId,
-        Long groupId,
         Long activityId,
         String title,
         String content,
         Long authorId,
-        String createdAt,
-        String updatedAt,
-        int commentCount,
+        String authorName,
+        String authorProfileImage,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt,
+        Long commentCount,
         boolean isDebate,
         boolean isAuthor
 ) {

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionPatchRequest.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionPatchRequest.java
@@ -1,0 +1,8 @@
+package qwerty.chaekit.dto.group.activity.discussion;
+
+public record DiscussionPatchRequest(
+        Long discussionId,
+        String title,
+        String content,
+        boolean isDebate
+) { }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionPatchRequest.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionPatchRequest.java
@@ -1,8 +1,7 @@
 package qwerty.chaekit.dto.group.activity.discussion;
 
 public record DiscussionPatchRequest(
-        Long discussionId,
         String title,
         String content,
-        boolean isDebate
+        Boolean isDebate
 ) { }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionPostRequest.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionPostRequest.java
@@ -1,0 +1,7 @@
+package qwerty.chaekit.dto.group.activity.discussion;
+
+public record DiscussionPostRequest(
+        String title,
+        String content,
+        boolean isDebate
+) { }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionPostRequest.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionPostRequest.java
@@ -1,7 +1,13 @@
 package qwerty.chaekit.dto.group.activity.discussion;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record DiscussionPostRequest(
+        @NotBlank
         String title,
+        @NotBlank
         String content,
-        boolean isDebate
+        @NotNull
+        Boolean isDebate
 ) { }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/enums/ErrorCode.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/enums/ErrorCode.java
@@ -19,6 +19,8 @@ public enum ErrorCode {
     GROUP_NAME_DUPLICATED("GROUP_NAME_DUPLICATED", "독서모임 이름이 중복되었습니다"),
     ACTIVITY_TIME_CONFLICT("ACTIVITY_TIME_CONFLICT", "이미 등록된 독서모임 일정과 겹칩니다"),
     ACTIVITY_TIME_INVALID("ACTIVITY_TIME_INVALID", "시작일과 종료일이 올바르지 않습니다"),
+    // discussion
+    DISCUSSION_NOT_YOURS("DISCUSSION_NOT_YOURS", "해당 토론은 본인이 작성한 것이 아닙니다"),
     // email
     EMAIL_VERIFICATION_FAILED("EMAIL_VERIFICATION_FAILED", "이메일 인증에 실패했습니다."),
     EMAIL_SEND_FAILED("EMAIL_SEND_FAILED", "이메일 전송에 실패했습니다."),
@@ -36,6 +38,7 @@ public enum ErrorCode {
     EXPIRED_REFRESH_TOKEN("EXPIRED_REFRESH_TOKEN", "Refresh Token이 만료되었습니다"),
 
     // FORBIDDEN
+    GROUP_MEMBER_ONLY("GROUP_MEMBER_ONLY", "독서모임에 가입된 회원만 사용할 수 있는 기능입니다"),
     GROUP_UPDATE_FORBIDDEN("GROUP_UPDATE_FORBIDDEN", "독서모임 수정 권한이 없습니다"),
     HIGHLIGHT_NOT_YOURS("HIGHLIGHT_NOT_YOURS", "하이라이트는 본인만 수정할 수 있습니다"),
     GROUP_LEADER_ONLY("GROUP_LEADER_ONLY", "모임지기만 사용할 수 있는 기능입니다"),
@@ -54,6 +57,7 @@ public enum ErrorCode {
     GROUP_NOT_FOUND("GROUP_NOT_FOUND", "해당 독서모임이 존재하지 않습니다"),
     HIGHLIGHT_NOT_FOUND("HIGHLIGHT_NOT_FOUND", "해당 하이라이트가 존재하지 않습니다"),
     ACTIVITY_NOT_FOUND("ACTIVITY_NOT_FOUND", "해당 활동이 존재하지 않습니다"),
+    DISCUSSION_NOT_FOUND("DISCUSSION_NOT_FOUND", "해당 토론이 존재하지 않습니다"),
 
     // Exception Handler
     INVALID_INPUT("INVALID_INPUT", "입력값이 유효하지 않습니다"),

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/enums/ErrorCode.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/enums/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     DISCUSSION_NOT_YOURS("DISCUSSION_NOT_YOURS", "해당 토론은 본인이 생성한 것이 아닙니다"),
     // discussion_comment
     INVALID_COMMENT_PARENT("INVALID_COMMENT_PARENT", "답글에는 다시 답글을 달 수 없습니다."),
+    DISCUSSION_COMMENT_DELETED("DISCUSSION_COMMENT_DELETED", "이미 삭제된 댓글입니다."),
     // email
     EMAIL_VERIFICATION_FAILED("EMAIL_VERIFICATION_FAILED", "이메일 인증에 실패했습니다."),
     EMAIL_SEND_FAILED("EMAIL_SEND_FAILED", "이메일 전송에 실패했습니다."),

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/enums/ErrorCode.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/enums/ErrorCode.java
@@ -20,7 +20,9 @@ public enum ErrorCode {
     ACTIVITY_TIME_CONFLICT("ACTIVITY_TIME_CONFLICT", "이미 등록된 독서모임 일정과 겹칩니다"),
     ACTIVITY_TIME_INVALID("ACTIVITY_TIME_INVALID", "시작일과 종료일이 올바르지 않습니다"),
     // discussion
-    DISCUSSION_NOT_YOURS("DISCUSSION_NOT_YOURS", "해당 토론은 본인이 작성한 것이 아닙니다"),
+    DISCUSSION_NOT_YOURS("DISCUSSION_NOT_YOURS", "해당 토론은 본인이 생성한 것이 아닙니다"),
+    // discussion_comment
+    INVALID_COMMENT_PARENT("INVALID_COMMENT_PARENT", "답글에는 다시 답글을 달 수 없습니다."),
     // email
     EMAIL_VERIFICATION_FAILED("EMAIL_VERIFICATION_FAILED", "이메일 인증에 실패했습니다."),
     EMAIL_SEND_FAILED("EMAIL_SEND_FAILED", "이메일 전송에 실패했습니다."),
@@ -44,10 +46,13 @@ public enum ErrorCode {
     GROUP_LEADER_ONLY("GROUP_LEADER_ONLY", "모임지기만 사용할 수 있는 기능입니다"),
     ACTIVITY_GROUP_MISMATCH("ACTIVITY_GROUP_MISMATCH", "해당 독서모임의 활동이 아닙니다"),
     ACTIVITY_MEMBER_ONLY("ACTIVITY_MEMBER_ONLY", "해당 독서모임 활동에 가입한 경우에만 가능합니다"),
+    DISCUSSION_COMMENT_NOT_YOURS("DISCUSSION_COMMENT_NOT_YOURS", "해당 댓글은 본인이 작성한 것이 아닙니다"),
+
     LOGIN_REQUIRED("LOGIN_REQUIRED", "로그인이 필요합니다"),
     ONLY_USER("ONLY_USER", "일반 회원만 사용할 수 있는 기능입니다"),
     ONLY_PUBLISHER("ONLY_PUBLISHER", "출판사 회원만 사용할 수 있는 기능입니다"),
     ONLY_ADMIN("ONLY_ADMIN", "관리자만 사용할 수 있는 기능입니다"),
+
 
     // NOT_FOUND
     MEMBER_NOT_FOUND("MEMBER_NOT_FOUND", "해당 회원이 존재하지 않습니다"),
@@ -58,7 +63,7 @@ public enum ErrorCode {
     HIGHLIGHT_NOT_FOUND("HIGHLIGHT_NOT_FOUND", "해당 하이라이트가 존재하지 않습니다"),
     ACTIVITY_NOT_FOUND("ACTIVITY_NOT_FOUND", "해당 활동이 존재하지 않습니다"),
     DISCUSSION_NOT_FOUND("DISCUSSION_NOT_FOUND", "해당 토론이 존재하지 않습니다"),
-
+    DISCUSSION_COMMENT_NOT_FOUND("DISCUSSION_COMMENT_NOT_FOUND", "해당 댓글이 존재하지 않습니다"),
     // Exception Handler
     INVALID_INPUT("INVALID_INPUT", "입력값이 유효하지 않습니다"),
     INVALID_HTTP_MESSAGE("INVALID_HTTP_MESSAGE", "HTTP 요청 본문이 잘못된 형식입니다."),

--- a/chaekit-spring/src/main/java/qwerty/chaekit/mapper/DiscussionMapper.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/mapper/DiscussionMapper.java
@@ -1,0 +1,106 @@
+package qwerty.chaekit.mapper;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import qwerty.chaekit.domain.group.activity.discussion.Discussion;
+import qwerty.chaekit.domain.group.activity.discussion.DiscussionComment;
+import qwerty.chaekit.dto.group.activity.discussion.DiscussionCommentFetchResponse;
+import qwerty.chaekit.dto.group.activity.discussion.DiscussionDetailResponse;
+import qwerty.chaekit.dto.group.activity.discussion.DiscussionFetchResponse;
+import qwerty.chaekit.service.util.S3Service;
+
+@Component
+@RequiredArgsConstructor
+public class DiscussionMapper {
+    private final S3Service s3Service;
+
+    public String convertToPublicImageURL(String imageKey) {
+        return s3Service.convertToPublicImageURL(imageKey);
+    }
+
+    /*
+     * @fetch-plan
+     * branch: feat/be/discussion
+     * date: 2025-05-06
+     * required:
+     *   - DiscussionComment.author a (ManyToOne, join fetch)
+     *   - DiscussionComment.replies r (OneToMany, batch fetch)
+     *      - r.author (ManyToOne, batch fetch)
+     */
+    public DiscussionCommentFetchResponse toCommentFetchResponse(DiscussionComment comment) {
+        return DiscussionCommentFetchResponse.builder()
+                .commentId(comment.getId())
+                .authorId(comment.getAuthor().getId())
+                .authorName(comment.getAuthor().getNickname())
+                .authorProfileImageURL(convertToPublicImageURL(comment.getAuthor().getProfileImageKey()))
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .modifiedAt(comment.getModifiedAt())
+                .isEdited(comment.isEdited())
+                .stance(comment.getStance())
+                .parentId(comment.getParent() != null ? comment.getParent().getId() : null)
+                .replies(
+                        comment.getReplies().stream()
+                                .map(this::toCommentFetchResponse)
+                                .toList()
+                )
+                .build();
+    }
+
+    /*
+     * @fetch-plan
+     * branch: feat/be/discussion
+     * date: 2025-05-06
+     * required:
+     *  - Discussion.author (ManyToOne, join fetch)
+     */
+    public DiscussionFetchResponse toFetchResponse(Discussion discussion, Long commentCount, Long memberId) {
+        return DiscussionFetchResponse.builder()
+                .discussionId(discussion.getId())
+                .activityId(discussion.getActivity().getId())
+                .title(discussion.getTitle())
+                .content(discussion.getContent())
+                .authorId(discussion.getAuthor().getId())
+                .authorName(discussion.getAuthor().getNickname())
+                .authorProfileImage(convertToPublicImageURL(discussion.getAuthor().getProfileImageKey()))
+                .createdAt(discussion.getCreatedAt())
+                .modifiedAt(discussion.getModifiedAt())
+                .commentCount(commentCount)
+                .isDebate(discussion.isDebate())
+                .isAuthor(discussion.getAuthor().getId().equals(memberId))
+                .build();
+    }
+
+    /*
+     * @fetch-plan
+     * branch: feat/be/discussion
+     * date: 2025-05-06
+     * required:
+     *  - Discussion.author (ManyToOne, join fetch)
+     *  - Discussion.comments c (OneToMany, join fetch)
+     *      - c.author (ManyToOne, batch fetch)
+     *      - c.replies r (OneToMany, batch fetch)
+     *         - r.author (ManyToOne, batch fetch)
+     */
+    public DiscussionDetailResponse toDetailResponse(Discussion discussion, Long commentCount, Long memberId) {
+        return DiscussionDetailResponse.builder()
+                .discussionId(discussion.getId())
+                .activityId(discussion.getActivity().getId())
+                .title(discussion.getTitle())
+                .content(discussion.getContent())
+                .authorId(discussion.getAuthor().getId())
+                .authorName(discussion.getAuthor().getNickname())
+                .authorProfileImage(convertToPublicImageURL(discussion.getAuthor().getProfileImageKey()))
+                .createdAt(discussion.getCreatedAt())
+                .modifiedAt(discussion.getModifiedAt())
+                .commentCount(commentCount)
+                .isDebate(discussion.isDebate())
+                .isAuthor(discussion.getAuthor().getId().equals(memberId))
+                .comments(
+                        discussion.getComments().stream()
+                                .map(this::toCommentFetchResponse)
+                                .toList()
+                )
+                .build();
+    }
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/mapper/DiscussionMapper.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/mapper/DiscussionMapper.java
@@ -28,6 +28,17 @@ public class DiscussionMapper {
      *      - r.author (ManyToOne, batch fetch)
      */
     public DiscussionCommentFetchResponse toCommentFetchResponse(DiscussionComment comment) {
+        if(comment.isDeleted()) {
+            return DiscussionCommentFetchResponse.builder()
+                    .commentId(comment.getId())
+                    .replies(
+                            comment.getReplies().stream()
+                                    .map(this::toCommentFetchResponse)
+                                    .toList()
+                    )
+                    .isDeleted(true)
+                    .build();
+        }
         return DiscussionCommentFetchResponse.builder()
                 .commentId(comment.getId())
                 .authorId(comment.getAuthor().getId())
@@ -98,6 +109,7 @@ public class DiscussionMapper {
                 .isAuthor(discussion.getAuthor().getId().equals(memberId))
                 .comments(
                         discussion.getComments().stream()
+                                .filter(comment -> comment.getParent() == null)
                                 .map(this::toCommentFetchResponse)
                                 .toList()
                 )

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/group/DiscussionService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/group/DiscussionService.java
@@ -1,0 +1,115 @@
+package qwerty.chaekit.service.group;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import qwerty.chaekit.domain.group.activity.ActivityRepository;
+import qwerty.chaekit.domain.group.activity.discussion.Discussion;
+import qwerty.chaekit.domain.group.activity.discussion.repository.DiscussionRepository;
+import qwerty.chaekit.domain.member.user.UserProfile;
+import qwerty.chaekit.domain.member.user.UserProfileRepository;
+import qwerty.chaekit.dto.group.activity.discussion.DiscussionDetailResponse;
+import qwerty.chaekit.dto.group.activity.discussion.DiscussionFetchResponse;
+import qwerty.chaekit.dto.group.activity.discussion.DiscussionPatchRequest;
+import qwerty.chaekit.dto.group.activity.discussion.DiscussionPostRequest;
+import qwerty.chaekit.dto.page.PageResponse;
+import qwerty.chaekit.global.enums.ErrorCode;
+import qwerty.chaekit.global.exception.BadRequestException;
+import qwerty.chaekit.global.exception.NotFoundException;
+import qwerty.chaekit.global.security.resolver.UserToken;
+import qwerty.chaekit.mapper.DiscussionMapper;
+
+import java.util.List;
+import java.util.Map;
+
+// TODO: 모든 메서드에서 activity 참여중인지 권한 확인 필요
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DiscussionService {
+    private final DiscussionRepository discussionRepository;
+    private final DiscussionMapper discussionMapper;
+    private final ActivityRepository activityRepository;
+    private final UserProfileRepository userRepository;
+
+
+    public PageResponse<DiscussionFetchResponse> getDiscussions(UserToken userToken, Pageable pageable, Long activityId) {
+        Long userId = userToken.userId();
+
+        Page<Discussion> discussions = discussionRepository.findByActivityId(activityId, pageable);
+        List<Long> discussionIdList = discussions.stream()
+                .map(Discussion::getId)
+                .toList();
+
+        // Get the count of comments for each discussion
+        Map<Long, Long> counts = discussionRepository.countCommentsByDiscussionIds(discussionIdList);
+
+        return PageResponse.of(discussions.map(discussion -> {
+            Long commentCount = counts.getOrDefault(discussion.getId(), 0L);
+            return discussionMapper.toFetchResponse(discussion, commentCount, userId);
+        }));
+    }
+
+    public DiscussionFetchResponse createDiscussion(UserToken userToken, Long activityId, DiscussionPostRequest request) {
+        if(!activityRepository.existsById(activityId)) {
+            throw new NotFoundException(ErrorCode.ACTIVITY_NOT_FOUND);
+        }
+
+        UserProfile user = userRepository.findById(userToken.userId())
+                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        Discussion discussion = Discussion.builder()
+                .activity(activityRepository.getReferenceById(activityId))
+                .title(request.title())
+                .content(request.content())
+                .author(user)
+                .isDebate(request.isDebate())
+                .build();
+
+
+        discussionRepository.save(discussion);
+
+        return discussionMapper.toFetchResponse(discussion, 0L, user.getId());
+    }
+
+    public DiscussionDetailResponse getDiscussionDetail(UserToken userToken, Long discussionId) {
+        Long userId = userToken.userId();
+
+        Discussion discussion = discussionRepository.findByIdWithAuthorAndComments(discussionId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.DISCUSSION_NOT_FOUND));
+        Long commentCount = discussionRepository.countCommentsByDiscussionId(discussion.getId());
+
+        return discussionMapper.toDetailResponse(discussion, commentCount, userId);
+    }
+
+    public DiscussionFetchResponse updateDiscussion(UserToken userToken, Long discussionId, DiscussionPatchRequest request) {
+        Long userId = userToken.userId();
+
+        Discussion discussion = getMyDiscussion(discussionId, userId);
+        Long commentCount = discussionRepository.countCommentsByDiscussionId(discussion.getId());
+
+        discussion.update(request.title(), request.content(), request.isDebate());
+
+        return discussionMapper.toFetchResponse(discussion, commentCount, userId);
+    }
+
+    public void deleteDiscussion(UserToken userToken, Long discussionId) {
+        Long userId = userToken.userId();
+
+        Discussion discussion = getMyDiscussion(discussionId, userId);
+
+        discussionRepository.delete(discussion);
+    }
+
+    private Discussion getMyDiscussion(Long discussionId, Long userId) {
+        Discussion discussion = discussionRepository.findById(discussionId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.DISCUSSION_NOT_FOUND));
+        if (!discussion.getAuthor().getId().equals(userId)) {
+            throw new BadRequestException(ErrorCode.DISCUSSION_NOT_YOURS);
+        }
+        return discussion;
+    }
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/group/DiscussionService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/group/DiscussionService.java
@@ -36,6 +36,7 @@ public class DiscussionService {
     private final DiscussionCommentRepository discussionCommentRepository;
 
 
+    @Transactional(readOnly = true)
     public PageResponse<DiscussionFetchResponse> getDiscussions(UserToken userToken, Pageable pageable, Long activityId) {
         Long userId = userToken.userId();
 
@@ -75,6 +76,7 @@ public class DiscussionService {
         return discussionMapper.toFetchResponse(discussion, 0L, user.getId());
     }
 
+    @Transactional(readOnly = true)
     public DiscussionDetailResponse getDiscussionDetail(UserToken userToken, Long discussionId) {
         Long userId = userToken.userId();
 

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/group/DiscussionService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/group/DiscussionService.java
@@ -7,13 +7,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import qwerty.chaekit.domain.group.activity.ActivityRepository;
 import qwerty.chaekit.domain.group.activity.discussion.Discussion;
+import qwerty.chaekit.domain.group.activity.discussion.DiscussionComment;
+import qwerty.chaekit.domain.group.activity.discussion.comment.DiscussionCommentRepository;
 import qwerty.chaekit.domain.group.activity.discussion.repository.DiscussionRepository;
 import qwerty.chaekit.domain.member.user.UserProfile;
 import qwerty.chaekit.domain.member.user.UserProfileRepository;
-import qwerty.chaekit.dto.group.activity.discussion.DiscussionDetailResponse;
-import qwerty.chaekit.dto.group.activity.discussion.DiscussionFetchResponse;
-import qwerty.chaekit.dto.group.activity.discussion.DiscussionPatchRequest;
-import qwerty.chaekit.dto.group.activity.discussion.DiscussionPostRequest;
+import qwerty.chaekit.dto.group.activity.discussion.*;
 import qwerty.chaekit.dto.page.PageResponse;
 import qwerty.chaekit.global.enums.ErrorCode;
 import qwerty.chaekit.global.exception.BadRequestException;
@@ -24,7 +23,7 @@ import qwerty.chaekit.mapper.DiscussionMapper;
 import java.util.List;
 import java.util.Map;
 
-// TODO: 모든 메서드에서 activity 참여중인지 권한 확인 필요
+// TODO: 모든 메서드에서 activity 참여중인지 권한 확인 필요(특히, GET, POST 메서드)
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +33,7 @@ public class DiscussionService {
     private final DiscussionMapper discussionMapper;
     private final ActivityRepository activityRepository;
     private final UserProfileRepository userRepository;
+    private final DiscussionCommentRepository discussionCommentRepository;
 
 
     public PageResponse<DiscussionFetchResponse> getDiscussions(UserToken userToken, Pageable pageable, Long activityId) {
@@ -45,7 +45,7 @@ public class DiscussionService {
                 .toList();
 
         // Get the count of comments for each discussion
-        Map<Long, Long> counts = discussionRepository.countCommentsByDiscussionIds(discussionIdList);
+        Map<Long, Long> counts = discussionCommentRepository.countCommentsByDiscussionIds(discussionIdList);
 
         return PageResponse.of(discussions.map(discussion -> {
             Long commentCount = counts.getOrDefault(discussion.getId(), 0L);
@@ -80,7 +80,7 @@ public class DiscussionService {
 
         Discussion discussion = discussionRepository.findByIdWithAuthorAndComments(discussionId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.DISCUSSION_NOT_FOUND));
-        Long commentCount = discussionRepository.countCommentsByDiscussionId(discussion.getId());
+        Long commentCount = discussionCommentRepository.countCommentsByDiscussionId(discussion.getId());
 
         return discussionMapper.toDetailResponse(discussion, commentCount, userId);
     }
@@ -89,7 +89,7 @@ public class DiscussionService {
         Long userId = userToken.userId();
 
         Discussion discussion = getMyDiscussion(discussionId, userId);
-        Long commentCount = discussionRepository.countCommentsByDiscussionId(discussion.getId());
+        Long commentCount = discussionCommentRepository.countCommentsByDiscussionId(discussion.getId());
 
         discussion.update(request.title(), request.content(), request.isDebate());
 
@@ -111,5 +111,77 @@ public class DiscussionService {
             throw new BadRequestException(ErrorCode.DISCUSSION_NOT_YOURS);
         }
         return discussion;
+    }
+
+    public DiscussionCommentFetchResponse getComment(Long commentId) {
+        DiscussionComment comment = discussionCommentRepository.findByIdWithAuthor(commentId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.DISCUSSION_COMMENT_NOT_FOUND));
+        return discussionMapper.toCommentFetchResponse(comment);
+    }
+
+    public DiscussionCommentFetchResponse addComment(Long discussionId, DiscussionCommentPostRequest request, UserToken userToken) {
+        if(!discussionRepository.existsById(discussionId)){
+            throw new NotFoundException(ErrorCode.DISCUSSION_NOT_FOUND);
+        }
+
+        DiscussionComment parentComment;
+        if(request.parentId() != null){
+            DiscussionComment comment = discussionCommentRepository.findById(request.parentId())
+                    .orElseThrow(() -> new NotFoundException(ErrorCode.DISCUSSION_COMMENT_NOT_FOUND));
+            if(comment.getParent() != null){
+                throw new BadRequestException(ErrorCode.INVALID_COMMENT_PARENT);
+            }
+            parentComment = discussionCommentRepository.getReferenceById(request.parentId());
+        } else {
+            parentComment = null;
+        }
+
+        DiscussionComment comment = DiscussionComment.builder()
+                .author(userRepository.getReferenceById(userToken.userId()))
+                .discussion(discussionRepository.getReferenceById(discussionId))
+                .content(request.content())
+                .parent(parentComment)
+                .stance(request.stance())
+                .build();
+        discussionCommentRepository.save(comment);
+        return discussionMapper.toCommentFetchResponse(comment);
+    }
+
+    public DiscussionCommentFetchResponse updateComment(Long commentId, DiscussionCommentPatchRequest request, UserToken userToken) {
+        DiscussionComment comment = discussionCommentRepository.findByIdWithAuthor(commentId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.DISCUSSION_COMMENT_NOT_FOUND));
+        if (!comment.getAuthor().getId().equals(userToken.userId())) {
+            throw new BadRequestException(ErrorCode.DISCUSSION_COMMENT_NOT_YOURS);
+        }
+        comment.updateContent(request.content());
+        return discussionMapper.toCommentFetchResponse(comment);
+    }
+
+    public void deleteComment(Long commentId, UserToken userToken) {
+        DiscussionComment comment = discussionCommentRepository.findByIdWithParent(commentId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.DISCUSSION_COMMENT_NOT_FOUND));
+
+        if (!comment.getAuthor().getId().equals(userToken.userId())) {
+            throw new BadRequestException(ErrorCode.DISCUSSION_COMMENT_NOT_YOURS);
+        }
+
+        // 대댓글이 있는 경우 soft delete
+        Long repliesCount = discussionCommentRepository.countByParentId(commentId);
+        if (repliesCount > 0) {
+            comment.softDelete();
+            return;
+        }
+
+        // 마지막 답글인 경우 부모 댓글도 삭제
+        if (comment.getParent() != null && comment.getParent().isDeleted()) {
+            long siblingCount = discussionCommentRepository.countByParentId(comment.getParent().getId());
+            if (siblingCount == 1) {
+                discussionCommentRepository.delete(comment);
+                discussionCommentRepository.delete(comment.getParent());
+                return;
+            }
+        }
+
+        discussionCommentRepository.delete(comment);
     }
 }

--- a/chaekit-spring/src/main/resources/db/migration/V9__add_columns_to_discussion_comment.sql
+++ b/chaekit-spring/src/main/resources/db/migration/V9__add_columns_to_discussion_comment.sql
@@ -1,0 +1,10 @@
+ALTER TABLE discussion_comment
+    ADD COLUMN is_deleted bit DEFAULT 0 NOT NULL,
+    ADD COLUMN is_edited bit DEFAULT 0 NOT NULL,
+    ADD COLUMN stance varchar(255) NOT NULL,
+    ADD COLUMN parent_id bigint DEFAULT NULL,
+    ADD KEY `FK_discussion_comment` (`parent_id`),
+ADD CONSTRAINT `FK_discussion_comment` FOREIGN KEY (`parent_id`) REFERENCES `discussion_comment` (`id`);
+
+ALTER TABLE discussion
+    ADD COLUMN is_debate bit DEFAULT 0 NOT NULL;

--- a/chaekit-spring/src/test/java/qwerty/chaekit/service/group/DiscussionServiceTest.java
+++ b/chaekit-spring/src/test/java/qwerty/chaekit/service/group/DiscussionServiceTest.java
@@ -1,0 +1,402 @@
+package qwerty.chaekit.service.group;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import qwerty.chaekit.domain.group.activity.Activity;
+import qwerty.chaekit.domain.group.activity.ActivityRepository;
+import qwerty.chaekit.domain.group.activity.discussion.Discussion;
+import qwerty.chaekit.domain.group.activity.discussion.DiscussionComment;
+import qwerty.chaekit.domain.group.activity.discussion.comment.DiscussionCommentRepository;
+import qwerty.chaekit.domain.group.activity.discussion.repository.DiscussionRepository;
+import qwerty.chaekit.domain.member.user.UserProfile;
+import qwerty.chaekit.domain.member.user.UserProfileRepository;
+import qwerty.chaekit.dto.group.activity.discussion.DiscussionCommentFetchResponse;
+import qwerty.chaekit.dto.group.activity.discussion.DiscussionCommentPostRequest;
+import qwerty.chaekit.dto.group.activity.discussion.DiscussionDetailResponse;
+import qwerty.chaekit.dto.group.activity.discussion.DiscussionFetchResponse;
+import qwerty.chaekit.dto.group.activity.discussion.DiscussionPatchRequest;
+import qwerty.chaekit.dto.group.activity.discussion.DiscussionPostRequest;
+import qwerty.chaekit.dto.page.PageResponse;
+import qwerty.chaekit.global.exception.BadRequestException;
+import qwerty.chaekit.global.security.resolver.UserToken;
+import qwerty.chaekit.mapper.DiscussionMapper;
+import qwerty.chaekit.service.util.S3Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DiscussionServiceTest {
+    private DiscussionService discussionService;
+
+    @Mock
+    private DiscussionRepository discussionRepository;
+
+    @Mock
+    private DiscussionCommentRepository discussionCommentRepository;
+
+    @Mock
+    private ActivityRepository activityRepository;
+
+    @Mock
+    private UserProfileRepository userProfileRepository;
+
+    @Mock
+    private S3Service s3Service;
+
+    @BeforeEach
+    void setUp() {
+        DiscussionMapper discussionMapper = new DiscussionMapper(s3Service);
+
+        discussionService = new DiscussionService(
+                discussionRepository,
+                discussionMapper,
+                activityRepository,
+                userProfileRepository,
+                discussionCommentRepository
+        );
+    }
+
+
+    @Test
+    void getDiscussions() {
+        // given
+        Long activityId = 1L;
+        UserToken userToken = UserToken.of(1L, 1L, "test@example.com");
+        UserProfile userProfile = UserProfile.builder()
+                .id(1L)
+                .build();
+        Activity activity = Activity.builder()
+                .id(activityId)
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Discussion discussion = Discussion.builder()
+                .id(1L)
+                .title("Test Discussion")
+                .content("This is a test discussion.")
+                .author(userProfile)
+                .activity(activity)
+                .isDebate(false)
+                .build();
+
+        given(discussionRepository.findByActivityId(activityId, pageable))
+                .willReturn(new PageImpl<>(List.of(discussion)));
+
+        given(discussionCommentRepository.countCommentsByDiscussionIds(List.of(1L)))
+                .willReturn(Map.of(1L, 5L));
+
+        // when
+        PageResponse<DiscussionFetchResponse> response = discussionService.getDiscussions(userToken, pageable, activityId);
+
+        // then
+        assertNotNull(response);
+        assertEquals(1, response.content().size());
+        DiscussionFetchResponse discussionResponse = response.content().get(0);
+        assertEquals("Test Discussion", discussionResponse.title());
+        assertEquals("This is a test discussion.", discussionResponse.content());
+        assertEquals(5L, discussionResponse.commentCount());
+        assertFalse(discussionResponse.isDebate());
+    }
+
+    @Test
+    void createDiscussion() {
+        // given
+        UserToken userToken = UserToken.of(1L, 1L, "test@example.com");
+        Long activityId = 1L;
+        DiscussionPostRequest request = new DiscussionPostRequest(
+                "Test Title",
+                "Test Content",
+                false
+        );
+        UserProfile user = UserProfile.builder()
+                .id(userToken.userId())
+                .build();
+
+        given(activityRepository.existsById(activityId))
+                .willReturn(true);
+        given(userProfileRepository.findById(activityId))
+                .willReturn(Optional.of(user));
+        given(activityRepository.getReferenceById(activityId))
+                .willReturn(Activity.builder().id(activityId).build());
+
+        // when
+        DiscussionFetchResponse response = discussionService.createDiscussion(userToken, activityId, request);
+        // then
+        assertNotNull(response);
+        assertEquals(activityId, response.activityId());
+        assertEquals(user.getId(), response.authorId());
+        assertEquals(request.title(), response.title());
+        assertEquals(request.content(), response.content());
+        assertEquals(request.isDebate(), response.isDebate());
+        assertEquals(0L, response.commentCount());
+        assertEquals(user.getId(), response.authorId());
+    }
+
+    @Test
+    void getDiscussionDetail() {
+        // given
+        Long discussionId = 1L;
+        UserToken userToken = UserToken.of(1L, 1L, "test@example.com");
+        UserProfile author = UserProfile.builder().id(1L).build();
+        Discussion discussion = Discussion.builder()
+                .id(discussionId)
+                .activity(Activity.builder().id(1L).build())
+                .title("Detail Test")
+                .content("Detail Content")
+                .author(author)
+                .isDebate(false)
+                .build();
+
+        given(discussionRepository.findByIdWithAuthorAndComments(discussionId))
+                .willReturn(Optional.of(discussion));
+        given(discussionCommentRepository.countCommentsByDiscussionId(discussionId))
+                .willReturn(3L);
+
+        // when
+        DiscussionDetailResponse response = discussionService.getDiscussionDetail(userToken, discussionId);
+
+        // then
+        assertNotNull(response);
+        assertEquals(discussionId, response.discussionId());
+        assertEquals("Detail Test", response.title());
+        assertEquals("Detail Content", response.content());
+        assertEquals(3L, response.commentCount());
+        assertFalse(response.isDebate());
+    }
+
+    @Test
+    void updateDiscussion() {
+        // given
+        Long discussionId = 1L;
+        UserToken userToken = UserToken.of(1L, 1L, "test@example.com");
+        DiscussionPatchRequest request = new DiscussionPatchRequest("Updated Title", "Updated Content", true);
+        UserProfile author = UserProfile.builder().id(1L).build();
+        Discussion discussion = Discussion.builder()
+                .id(discussionId)
+                .activity(Activity.builder().id(1L).build())
+                .title("Old Title")
+                .content("Old Content")
+                .author(author)
+                .isDebate(false)
+                .build();
+
+        given(discussionRepository.findById(discussionId))
+                .willReturn(Optional.of(discussion));
+        given(discussionCommentRepository.countCommentsByDiscussionId(discussionId))
+                .willReturn(2L);
+
+        // when
+        DiscussionFetchResponse response = discussionService.updateDiscussion(userToken, discussionId, request);
+
+        // then
+        assertNotNull(response);
+        assertEquals("Updated Title", response.title());
+        assertEquals("Updated Content", response.content());
+        assertTrue(response.isDebate());
+        assertEquals(2L, response.commentCount());
+    }
+
+    @Test
+    void deleteDiscussion_성공() {
+        // given
+        Long discussionId = 1L;
+        UserToken userToken = UserToken.of(1L, 1L, "test@example.com");
+        UserProfile author = UserProfile.builder().id(1L).build();
+        Discussion discussion = Discussion.builder()
+                .activity(Activity.builder().id(1L).build())
+                .id(discussionId)
+                .author(author)
+                .build();
+
+        given(discussionRepository.findById(discussionId))
+                .willReturn(Optional.of(discussion));
+
+        // when
+        discussionService.deleteDiscussion(userToken, discussionId);
+
+        // then
+        verify(discussionRepository, times(1)).delete(discussion);
+    }
+
+    @Test
+    void deleteDiscussion_작성자가_아님() {
+        // given
+        Long discussionId = 1L;
+        UserToken userToken = UserToken.of(2L, 2L, "not-author@example.com"); // 다른 사용자
+        UserProfile author = UserProfile.builder().id(1L).build();
+        Discussion discussion = Discussion.builder()
+                .activity(Activity.builder().id(1L).build())
+                .id(discussionId)
+                .author(author)
+                .build();
+
+        given(discussionRepository.findById(discussionId))
+                .willReturn(Optional.of(discussion));
+
+        // when & then
+        assertThrows(BadRequestException.class, () -> discussionService.deleteDiscussion(userToken, discussionId));
+    }
+
+    @Test
+    void addComment() {
+        // given
+        Long discussionId = 1L;
+        Long userId = 1L;
+        UserToken userToken = UserToken.of(userId, 1L, "test@example.com");
+        DiscussionCommentPostRequest request = new DiscussionCommentPostRequest(null, "Test Comment", null);
+        UserProfile author = UserProfile.builder().id(userId).build();
+        Discussion discussion = Discussion.builder().id(discussionId).build();
+        DiscussionComment comment = DiscussionComment.builder()
+                .id(1L)
+                .author(author)
+                .discussion(discussion)
+                .content("Test Comment")
+                .build();
+
+        given(discussionRepository.existsById(discussionId)).willReturn(true);
+        given(userProfileRepository.getReferenceById(userId)).willReturn(author);
+        given(discussionRepository.getReferenceById(discussionId)).willReturn(discussion);
+        given(discussionCommentRepository.save(any(DiscussionComment.class))).willReturn(comment);
+
+        // when
+        DiscussionCommentFetchResponse response = discussionService.addComment(discussionId, request, userToken);
+
+        // then
+        assertNotNull(response);
+        assertEquals("Test Comment", response.content());
+        assertEquals(userId, response.authorId());
+    }
+
+    @Test
+    void deleteComment() {
+        // given
+        Long commentId = 1L;
+        Long userId = 1L;
+        UserToken userToken = UserToken.of(userId, 1L, "test@example.com");
+        DiscussionComment comment = DiscussionComment.builder()
+                .id(commentId)
+                .author(UserProfile.builder().id(userId).build())
+                .build();
+
+        given(discussionCommentRepository.findByIdWithParent(commentId))
+                .willReturn(Optional.of(comment));
+        given(discussionCommentRepository.countByParentId(commentId))
+                .willReturn(0L);
+
+        // when
+        discussionService.deleteComment(commentId, userToken);
+
+        // then
+        verify(discussionCommentRepository, times(1)).delete(comment);
+    }
+
+    @Test
+    void deleteComment_대댓글이_존재하는_댓글_삭제() {
+        // given
+        Long commentId = 1L;
+        Long userId = 1L;
+        UserToken userToken = UserToken.of(userId, 1L, "test@example.com");
+        DiscussionComment comment = DiscussionComment.builder()
+                .id(commentId)
+                .author(UserProfile.builder().id(userId).build())
+                .build();
+
+        given(discussionCommentRepository.findByIdWithParent(commentId))
+                .willReturn(Optional.of(comment));
+        given(discussionCommentRepository.countByParentId(commentId))
+                .willReturn(1L); // 대댓글이 존재
+
+        // when
+        discussionService.deleteComment(commentId, userToken);
+
+        // then
+        assertTrue(comment.isDeleted());
+        verify(discussionCommentRepository, never()).delete(comment);
+    }
+
+    @Test
+    void deleteComment_이미_삭제된_댓글의_마지막_대댓글_삭제() {
+        // given
+        Long parentCommentId = 1L;
+        Long replyCommentId = 2L;
+        Long userId = 1L;
+        UserToken userToken = UserToken.of(userId, 1L, "test@example.com");
+        DiscussionComment parentComment = DiscussionComment.builder()
+                .id(parentCommentId)
+                .author(UserProfile.builder().id(userId).build())
+                .build();
+        parentComment.softDelete();
+        DiscussionComment replyComment = DiscussionComment.builder()
+                .id(replyCommentId)
+                .author(UserProfile.builder().id(userId).build())
+                .parent(parentComment)
+                .build();
+
+        given(discussionCommentRepository.findByIdWithParent(replyCommentId))
+                .willReturn(Optional.of(replyComment));
+        given(discussionCommentRepository.countByParentId(parentCommentId))
+                .willReturn(1L); // 마지막 대댓글
+        given(discussionCommentRepository.countByParentId(replyCommentId))
+                .willReturn(0L); // 대댓글에는 대댓글 없음
+
+        // when
+        discussionService.deleteComment(replyCommentId, userToken);
+
+        // then
+        verify(discussionCommentRepository, times(1)).delete(replyComment);
+        verify(discussionCommentRepository, times(1)).delete(parentComment);
+    }
+
+    @Test
+    void deleteComment_작성자가_아님() {
+        // given
+        Long commentId = 1L;
+        Long userId = 2L; // 다른 사용자
+        UserToken userToken = UserToken.of(1L, userId, "not-author@example.com");
+        DiscussionComment comment = DiscussionComment.builder()
+                .id(commentId)
+                .author(UserProfile.builder().id(1L).build()) // 작성자 ID가 다름
+                .build();
+
+        given(discussionCommentRepository.findByIdWithParent(commentId))
+                .willReturn(Optional.of(comment));
+
+        // when & then
+        assertThrows(BadRequestException.class, () -> discussionService.deleteComment(commentId, userToken));
+    }
+
+    @Test
+    void deleteComment_대댓글_없이_삭제() {
+        // given
+        Long commentId = 1L;
+        Long userId = 1L;
+        UserToken userToken = UserToken.of(userId, 1L, "test@example.com");
+        DiscussionComment comment = DiscussionComment.builder()
+                .id(commentId)
+                .author(UserProfile.builder().id(userId).build())
+                .build();
+
+        given(discussionCommentRepository.findByIdWithParent(commentId))
+                .willReturn(Optional.of(comment));
+        given(discussionCommentRepository.countByParentId(commentId))
+                .willReturn(0L); // 대댓글 없음
+
+        // when
+        discussionService.deleteComment(commentId, userToken);
+
+        // then
+        verify(discussionCommentRepository, times(1)).delete(comment);
+    }
+}


### PR DESCRIPTION
## ✨ 작업 개요
토론 게시글 CRUD
토론 댓글 CRUD

## ✅ 작업 내용
[토론 CRUD]
GET /api/activities/{activityId}/discussions

[토론 CRUD]
GET /api/discussions/{discussionId}
POST /api/activities/{activityId}/discussions
PATCH /api/discussions/{discussionId}
DELETE /api/discussions/{discussionId}


[댓글 목록]
GET /api/discussions/{discussionId}/comments

[댓글 CRUD]
GET /api/discussions/comments/{commentId}
POST /api/discussions/{discussionId}/comments
PATCH /api/discussions/comments/{commentId}
DELETE /api/discussions/comments/{commentId}


## 📎 관련 이슈
Closes #74 

## 🧪 테스트 방법
Postman

## 💬 기타
- 현재 활동 가입 기능이 없는 관계로 모든 사용자가 토론글 작성, 토론 댓글이 가능함(추후에 막을 예정, #186)
- 토론 Stance enum 값: {"AGREE", "DISAGREE", "NEUTRAL"}
- 토론 댓글은 답글에 대한 답글은 불가능 처리
- 토론 댓글에 isDeleted라는 속성 추가
  - 답글이 달려있는 상태에서 댓글을 삭제하면 그 댓글은 "삭제된 댓글입니다."로 내용이 바뀜. (soft delet)
  - soft delete 상태의 댓글은 id, replies, isDeleted를 제외한 모든 필드가 null로 표시됨.
  - soft delete 상태의 댓글에서 답글이 전부 삭제되면 완전히 댓글이 사라짐.
  - soft delete 상태의 댓글에 답글, 수정 불가능
