### PR TITLE
[FIX] API 클라이언트 FormData 처리 수정

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "api": "swagger-typescript-api generate -p ./api.json -o ./src/api/ --module-name-first-tag -n api.gen.ts",
+    "api": "swagger-typescript-api generate -p ./api.json -o ./src/api/ --module-name-first-tag -n api.gen.ts --templates ./swaggerTemplates",
     "dev": "vite",
     "build": "vite build && tsc -b",
     "lint": "eslint .",

--- a/client/src/api/api.gen.ts
+++ b/client/src/api/api.gen.ts
@@ -290,6 +290,12 @@ export interface DiscussionCommentPostRequest {
   stance: "AGREE" | "DISAGREE" | "NEUTRAL";
 }
 
+/** API 에러 응답을 감싸는 클래스 */
+export interface ApiSuccessResponseDiscussionCommentFetchResponse {
+  isSuccessful?: boolean;
+  data?: DiscussionCommentFetchResponse;
+}
+
 export interface DiscussionCommentFetchResponse {
   /** @format int64 */
   commentId?: number;
@@ -308,6 +314,29 @@ export interface DiscussionCommentFetchResponse {
   /** @format int64 */
   parentId?: number;
   replies?: DiscussionCommentFetchResponse[];
+}
+
+/** API 에러 응답을 감싸는 클래스 */
+export interface ApiSuccessResponseCreditPaymentApproveResponse {
+  isSuccessful?: boolean;
+  data?: CreditPaymentApproveResponse;
+}
+
+export interface CreditPaymentApproveResponse {
+  orderId?: string;
+  /** @format int32 */
+  creditProductId?: number;
+  creditProductName?: string;
+  paymentMethod?: string;
+  /** @format int32 */
+  paymentAmount?: number;
+  /** @format date-time */
+  approvedAt?: string;
+}
+
+export interface CreditPaymentReadyRequest {
+  /** @format int64 */
+  creditProductId?: number;
 }
 
 /** 전자책 업로드 요청 데이터 */
@@ -358,6 +387,12 @@ export interface DiscussionPostRequest {
   isDebate: boolean;
 }
 
+/** API 에러 응답을 감싸는 클래스 */
+export interface ApiSuccessResponseDiscussionFetchResponse {
+  isSuccessful?: boolean;
+  data?: DiscussionFetchResponse;
+}
+
 export interface DiscussionFetchResponse {
   /** @format int64 */
   discussionId?: number;
@@ -404,7 +439,6 @@ export interface ActivityPatchRequest {
 export interface DiscussionPatchRequest {
   title?: string;
   content?: string;
-  isDebate?: boolean;
 }
 
 export interface DiscussionCommentPatchRequest {
@@ -451,6 +485,10 @@ export interface HighlightFetchResponse {
   id?: number;
   /** @format int64 */
   bookId?: number;
+  /** @format int64 */
+  authorId?: number;
+  authorName?: string;
+  authorProfileImageURL?: string;
   spine?: string;
   cfi?: string;
   memo?: string;
@@ -564,6 +602,12 @@ export interface PageResponseActivityFetchResponse {
   totalPages?: number;
 }
 
+/** API 에러 응답을 감싸는 클래스 */
+export interface ApiSuccessResponseDiscussionDetailResponse {
+  isSuccessful?: boolean;
+  data?: DiscussionDetailResponse;
+}
+
 export interface DiscussionDetailResponse {
   /** @format int64 */
   discussionId?: number;
@@ -584,6 +628,65 @@ export interface DiscussionDetailResponse {
   isDebate?: boolean;
   isAuthor?: boolean;
   comments?: DiscussionCommentFetchResponse[];
+}
+
+/** API 에러 응답을 감싸는 클래스 */
+export interface ApiSuccessResponseListCreditProductInfoResponse {
+  isSuccessful?: boolean;
+  data?: CreditProductInfoResponse[];
+}
+
+export interface CreditProductInfoResponse {
+  /** @format int32 */
+  id?: number;
+  /** @format int32 */
+  creditAmount?: number;
+  /** @format int32 */
+  price?: number;
+}
+
+/** API 에러 응답을 감싸는 클래스 */
+export interface ApiSuccessResponseCreditWalletResponse {
+  isSuccessful?: boolean;
+  data?: CreditWalletResponse;
+}
+
+export interface CreditWalletResponse {
+  /** @format int64 */
+  walletId?: number;
+  /** @format int64 */
+  balance?: number;
+}
+
+/** API 에러 응답을 감싸는 클래스 */
+export interface ApiSuccessResponsePageResponseCreditTransactionResponse {
+  isSuccessful?: boolean;
+  data?: PageResponseCreditTransactionResponse;
+}
+
+export interface CreditTransactionResponse {
+  orderId?: string;
+  /** @format int32 */
+  productId?: number;
+  productName?: string;
+  type?: "CHARGE" | "USE" | "REFUND";
+  /** @format int32 */
+  creditAmount?: number;
+  /** @format int32 */
+  paymentAmount?: number;
+  description?: string;
+  /** @format date-time */
+  approvedAt?: string;
+}
+
+export interface PageResponseCreditTransactionResponse {
+  content?: CreditTransactionResponse[];
+  /** @format int32 */
+  currentPage?: number;
+  /** @format int64 */
+  totalItems?: number;
+  /** @format int32 */
+  totalPages?: number;
 }
 
 /** API 에러 응답을 감싸는 클래스 */
@@ -682,6 +785,12 @@ export interface PageResponsePublisherInfoResponse {
   totalItems?: number;
   /** @format int32 */
   totalPages?: number;
+}
+
+/** API 에러 응답을 감싸는 클래스 */
+export interface ApiSuccessResponsePageResponseDiscussionFetchResponse {
+  isSuccessful?: boolean;
+  data?: PageResponseDiscussionFetchResponse;
 }
 
 export interface PageResponseDiscussionFetchResponse {
@@ -813,16 +922,25 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
-        formData.append(
-          key,
-          property instanceof Blob
-            ? property
-            : typeof property === "object" && property !== null
-              ? JSON.stringify(property)
-              : `${property}`,
-        );
+        if (property === undefined || property === null) {
+          return formData;
+        }
+        if (property instanceof Blob) {
+          formData.append(key, property);
+          return formData;
+        }
+        if (property instanceof Array) {
+          return property.reduce((property) => {
+            formData.append(key, property);
+            return formData;
+          }, formData);
+        }
+        if (typeof property === "object" && property !== null) {
+          formData.append(key, JSON.stringify(property));
+          return formData;
+        }
         return formData;
-      }, new FormData()),
+      }, formData),
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),
   };
 
@@ -1346,15 +1464,14 @@ export class Api<
      */
     updateGroup: (
       groupId: number,
-      query: {
-        request: GroupPatchRequest;
-      },
+      data: GroupPatchRequest,
       params: RequestParams = {},
     ) =>
       this.request<ApiSuccessResponseGroupPostResponse, any>({
         path: `/api/groups/${groupId}`,
         method: "PATCH",
-        query: query,
+        body: data,
+        type: ContentType.FormData,
         ...params,
       }),
 
@@ -1592,7 +1709,7 @@ export class Api<
       data: DiscussionCommentPostRequest,
       params: RequestParams = {},
     ) =>
-      this.request<DiscussionCommentFetchResponse, any>({
+      this.request<ApiSuccessResponseDiscussionCommentFetchResponse, any>({
         path: `/api/discussions/${discussionId}/comments`,
         method: "POST",
         body: data,
@@ -1628,7 +1745,7 @@ export class Api<
       },
       params: RequestParams = {},
     ) =>
-      this.request<PageResponseDiscussionFetchResponse, any>({
+      this.request<ApiSuccessResponsePageResponseDiscussionFetchResponse, any>({
         path: `/api/activities/${activityId}/discussions`,
         method: "GET",
         query: query,
@@ -1648,7 +1765,7 @@ export class Api<
       data: DiscussionPostRequest,
       params: RequestParams = {},
     ) =>
-      this.request<DiscussionFetchResponse, any>({
+      this.request<ApiSuccessResponseDiscussionFetchResponse, any>({
         path: `/api/activities/${activityId}/discussions`,
         method: "POST",
         body: data,
@@ -1665,7 +1782,7 @@ export class Api<
      * @request GET:/api/discussions/{discussionId}
      */
     getDiscussion: (discussionId: number, params: RequestParams = {}) =>
-      this.request<DiscussionDetailResponse, any>({
+      this.request<ApiSuccessResponseDiscussionDetailResponse, any>({
         path: `/api/discussions/${discussionId}`,
         method: "GET",
         ...params,
@@ -1680,7 +1797,7 @@ export class Api<
      * @request DELETE:/api/discussions/{discussionId}
      */
     deleteDiscussion: (discussionId: number, params: RequestParams = {}) =>
-      this.request<void, any>({
+      this.request<ApiSuccessResponseVoid, any>({
         path: `/api/discussions/${discussionId}`,
         method: "DELETE",
         ...params,
@@ -1699,7 +1816,7 @@ export class Api<
       data: DiscussionPatchRequest,
       params: RequestParams = {},
     ) =>
-      this.request<DiscussionFetchResponse, any>({
+      this.request<ApiSuccessResponseDiscussionFetchResponse, any>({
         path: `/api/discussions/${discussionId}`,
         method: "PATCH",
         body: data,
@@ -1716,7 +1833,7 @@ export class Api<
      * @request GET:/api/discussions/comments/{commentId}
      */
     getComment: (commentId: number, params: RequestParams = {}) =>
-      this.request<DiscussionCommentFetchResponse, any>({
+      this.request<ApiSuccessResponseDiscussionCommentFetchResponse, any>({
         path: `/api/discussions/comments/${commentId}`,
         method: "GET",
         ...params,
@@ -1731,7 +1848,7 @@ export class Api<
      * @request DELETE:/api/discussions/comments/{commentId}
      */
     deleteComment1: (commentId: number, params: RequestParams = {}) =>
-      this.request<void, any>({
+      this.request<ApiSuccessResponseVoid, any>({
         path: `/api/discussions/comments/${commentId}`,
         method: "DELETE",
         ...params,
@@ -1750,11 +1867,120 @@ export class Api<
       data: DiscussionCommentPatchRequest,
       params: RequestParams = {},
     ) =>
-      this.request<DiscussionCommentFetchResponse, any>({
+      this.request<ApiSuccessResponseDiscussionCommentFetchResponse, any>({
         path: `/api/discussions/comments/${commentId}`,
         method: "PATCH",
         body: data,
         type: ContentType.Json,
+        ...params,
+      }),
+  };
+  creditController = {
+    /**
+     * @description 카카오페이 결제 승인 후, 결제 정보를 저장합니다. (결제 승인)
+     *
+     * @tags credit-controller
+     * @name KakaoPaySuccess
+     * @summary 카카오페이 결제 승인
+     * @request POST:/api/credits/payment/success
+     */
+    kakaoPaySuccess: (
+      query: {
+        pg_token: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<ApiSuccessResponseCreditPaymentApproveResponse, any>({
+        path: `/api/credits/payment/success`,
+        method: "POST",
+        query: query,
+        ...params,
+      }),
+
+    /**
+     * @description 특정 크레딧 상품에 대해 카카오페이 결제를 요청합니다. (결제 준비)
+     *
+     * @tags credit-controller
+     * @name RequestKakaoPay
+     * @summary 카카오페이 결제 redirect URL 요청
+     * @request POST:/api/credits/payment/ready
+     */
+    requestKakaoPay: (
+      data: CreditPaymentReadyRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<ApiSuccessResponseString, any>({
+        path: `/api/credits/payment/ready`,
+        method: "POST",
+        body: data,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description 크레딧 상품 목록을 조회합니다. (구매 가능 상품만 조회)
+     *
+     * @tags credit-controller
+     * @name GetCreditProductList
+     * @summary 크레딧 상품 목록 조회
+     * @request GET:/api/credits
+     */
+    getCreditProductList: (params: RequestParams = {}) =>
+      this.request<ApiSuccessResponseListCreditProductInfoResponse, any>({
+        path: `/api/credits`,
+        method: "GET",
+        ...params,
+      }),
+
+    /**
+     * @description 내 크레딧 지갑 정보를 조회합니다.
+     *
+     * @tags credit-controller
+     * @name GetMyWallet
+     * @summary 내 크레딧 지갑 조회
+     * @request GET:/api/credits/wallets
+     */
+    getMyWallet: (params: RequestParams = {}) =>
+      this.request<ApiSuccessResponseCreditWalletResponse, any>({
+        path: `/api/credits/wallets`,
+        method: "GET",
+        ...params,
+      }),
+
+    /**
+     * @description 내 크레딧 거래 내역을 조회합니다. (구매, 사용 내역 포함)
+     *
+     * @tags credit-controller
+     * @name GetMyWalletTransactions
+     * @summary 내 크레딧 거래 내역 조회
+     * @request GET:/api/credits/transactions
+     */
+    getMyWalletTransactions: (
+      query?: {
+        /**
+         * Zero-based page index (0..N)
+         * @min 0
+         * @default 0
+         */
+        page?: number;
+        /**
+         * The size of the page to be returned
+         * @min 1
+         * @default 20
+         */
+        size?: number;
+        /** Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported. */
+        sort?: string[];
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<
+        ApiSuccessResponsePageResponseCreditTransactionResponse,
+        any
+      >({
+        path: `/api/credits/transactions`,
+        method: "GET",
+        query: query,
         ...params,
       }),
   };

--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -1,77 +1,7 @@
 import { getDefaultStore } from "jotai";
 import { ENV } from "../env";
-import { Api, HttpResponse } from "./api.gen";
+import { Api } from "./api.gen";
 import State from "../states";
-
-type UnsafeApiResponseBody = {
-  isSuccessful?: boolean;
-  data?: unknown;
-  error?: unknown;
-};
-
-type SafeApiResponseBody<D, E> =
-  | {
-      isSuccessful: true;
-      data: D;
-    }
-  | {
-      isSuccessful: false;
-      error: E;
-      errorCode: string;
-      errorMessage: string;
-    };
-
-export async function wrapApiResponse<
-  R extends HttpResponse<UnsafeApiResponseBody>,
-  SafeBody = SafeApiResponseBody<
-    NonNullable<R["data"]["data"]>,
-    NonNullable<R["data"]["error"]>
-  >,
->(response: Promise<R>): Promise<SafeBody> {
-  const data: UnsafeApiResponseBody = await response
-    .then(async (response) => {
-      const data: UnsafeApiResponseBody | undefined =
-        response.data ||
-        (await response.json().catch((error) => {
-          console.error("Failed to parse JSON", error);
-          return undefined;
-        }));
-
-      if (data) {
-        return data;
-      }
-
-      return {
-        isSuccessful: false,
-        error: "NO_DATA",
-        errorCode: "NO_DATA",
-        errorMessage: "No data received from server.",
-      };
-    })
-    .catch(async (error: R) => {
-      return await error.json();
-    });
-
-  if (typeof data.isSuccessful === "boolean") {
-    if (!data.isSuccessful) {
-      if ((data as any).errorCode === "EXPIRED_ACCESS_TOKEN") {
-        getDefaultStore().set(
-          State.Auth.refreshState,
-          State.Auth.RefreshState.NEED_REFRESH
-        );
-      }
-      console.error(data);
-    }
-    return data as unknown as SafeBody;
-  }
-
-  return {
-    isSuccessful: false,
-    error: "UNKNOWN_ERROR",
-    errorCode: "UNKNOWN_ERROR",
-    errorMessage: "An unknown error occurred.",
-  } as SafeBody;
-}
 
 const api = new Api<string>({
   baseUrl: ENV.CHAEKIT_API_ENDPOINT,
@@ -84,6 +14,12 @@ const api = new Api<string>({
         ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
       },
     };
+  },
+  onExpiredAccessToken: () => {
+    getDefaultStore().set(
+      State.Auth.refreshState,
+      State.Auth.RefreshState.NEED_REFRESH
+    );
   },
 });
 

--- a/client/src/api/login/useLogout.ts
+++ b/client/src/api/login/useLogout.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import State from "../../states";
-import API_CLIENT, { wrapApiResponse } from "../api";
+import API_CLIENT from "../api";
 import { useAtom } from "jotai";
 
 export default function useLogout() {
@@ -13,11 +13,9 @@ export default function useLogout() {
 
     let refreshToken = loggedInUser?.refreshToken;
     if (refreshToken) {
-      await wrapApiResponse(
-        API_CLIENT.tokenController.logout({
-          refreshToken,
-        })
-      );
+      await API_CLIENT.tokenController.logout({
+        refreshToken,
+      });
     }
   }, [loggedInUser, setLoggedInUser]);
 

--- a/client/src/api/login/useRefresh.ts
+++ b/client/src/api/login/useRefresh.ts
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import { AuthState } from "../../states/auth";
 import { useAtomValue, useSetAtom } from "jotai";
-import API_CLIENT, { wrapApiResponse } from "../api";
+import API_CLIENT from "../api";
 import useLogout from "./useLogout";
 import State from "../../states";
 
@@ -14,11 +14,9 @@ export default function useRefresh() {
   const refresh = useCallback(async () => {
     if (!user) return;
 
-    const response = await wrapApiResponse(
-      API_CLIENT.tokenController.refreshAccessToken({
-        refreshToken: user.refreshToken,
-      })
-    );
+    const response = await API_CLIENT.tokenController.refreshAccessToken({
+      refreshToken: user.refreshToken,
+    });
 
     if (!response.isSuccessful) {
       console.error("Failed to refresh token", response.errorCode);

--- a/client/src/component/HighlightBrowserModal.tsx
+++ b/client/src/component/HighlightBrowserModal.tsx
@@ -20,7 +20,7 @@ import { Highlight } from "../types/highlight";
 import { Fragment, useState } from "react";
 import { Delete, Edit, Sort } from "@mui/icons-material";
 import { useInfiniteQuery } from "@tanstack/react-query";
-import API_CLIENT, { wrapApiResponse } from "../api/api";
+import API_CLIENT from "../api/api";
 
 type HighlightFilterKind = {
   kind: "MyHighlights";
@@ -53,13 +53,11 @@ export default function HighlightBrowserModal(props: {
   } = useInfiniteQuery({
     queryKey: ["highlights", highlightFilterKind],
     queryFn: async ({ pageParam }) => {
-      const response = await wrapApiResponse(
-        API_CLIENT.highlightController.getHighlights({
-          page: pageParam,
-          size: 30,
-          ...getHighlightFilter(highlightFilterKind),
-        })
-      );
+      const response = await API_CLIENT.highlightController.getHighlights({
+        page: pageParam,
+        size: 30,
+        ...getHighlightFilter(highlightFilterKind),
+      });
       if (!response.isSuccessful) {
         console.error(response.errorCode);
         throw new Error(response.errorCode);

--- a/client/src/component/groupCreate/GroupCreateModal.tsx
+++ b/client/src/component/groupCreate/GroupCreateModal.tsx
@@ -1,6 +1,6 @@
 import { Container, Modal } from "@mui/material";
 import GroupEditForm, { GroupEditData } from "./GroupEditForm";
-import API_CLIENT, { wrapApiResponse } from "../../api/api";
+import API_CLIENT from "../../api/api";
 import { useNavigate } from "@tanstack/react-router";
 
 export default function GroupCreateModal(props: {
@@ -13,14 +13,12 @@ export default function GroupCreateModal(props: {
 
   const handleEditDone = async (data: GroupEditData) => {
     const { name, description, tags, groupImage } = data;
-    const response = await wrapApiResponse(
-      API_CLIENT.groupController.createGroup({
-        name,
-        description,
-        tags,
-        groupImage,
-      })
-    );
+    const response = await API_CLIENT.groupController.createGroup({
+      name,
+      description,
+      tags,
+      groupImage,
+    });
 
     if (!response.isSuccessful) {
       console.error(response.errorMessage);

--- a/client/src/component/groupList.tsx
+++ b/client/src/component/groupList.tsx
@@ -10,7 +10,7 @@ import {
   Typography,
 } from "@mui/material";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
-import API_CLIENT, { wrapApiResponse } from "../api/api";
+import API_CLIENT from "../api/api";
 import { JSX, PropsWithChildren, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import PageNavigation from "./PageNavigation";
@@ -33,13 +33,11 @@ export default function GroupList(props: {
   const { data: groups } = useQuery({
     queryKey: ["groupList", page, sort, pageSize],
     queryFn: async () => {
-      const response = await wrapApiResponse(
-        API_CLIENT.groupController.getAllGroups({
-          page,
-          size: pageSize,
-          sort,
-        })
-      );
+      const response = await API_CLIENT.groupController.getAllGroups({
+        page,
+        size: pageSize,
+        sort,
+      });
 
       if (response.isSuccessful) {
         setTotalPages(response.data.totalPages!);

--- a/client/src/routes/_pathlessLayout/admin/books.tsx
+++ b/client/src/routes/_pathlessLayout/admin/books.tsx
@@ -12,7 +12,7 @@ import {
 import { createFileRoute } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { BookMetadata } from "../../../types/book";
-import API_CLIENT, { wrapApiResponse } from "../../../api/api";
+import API_CLIENT from "../../../api/api";
 
 export const Route = createFileRoute("/_pathlessLayout/admin/books")({
   component: RouteComponent,
@@ -22,7 +22,7 @@ function RouteComponent() {
   const [books, setBooks] = useState<BookMetadata[]>([]);
 
   useEffect(() => {
-    wrapApiResponse(API_CLIENT.ebookController.getBooks()).then((response) => {
+    API_CLIENT.ebookController.getBooks().then((response) => {
       if (response.isSuccessful) {
         const books =
           response.data.content?.map((book) => {

--- a/client/src/routes/_pathlessLayout/admin/publisher.tsx
+++ b/client/src/routes/_pathlessLayout/admin/publisher.tsx
@@ -22,7 +22,7 @@ import {
   Typography,
 } from "@mui/material";
 import { useQuery } from "@tanstack/react-query";
-import API_CLIENT, { wrapApiResponse } from "../../../api/api";
+import API_CLIENT from "../../../api/api";
 import PageNavigation from "../../../component/PageNavigation";
 
 export const Route = createFileRoute("/_pathlessLayout/admin/publisher")({
@@ -44,12 +44,10 @@ function PublisherCard() {
   const { data: publishers, isLoading } = useQuery({
     queryKey: ["publishers", page],
     queryFn: async () => {
-      const response = await wrapApiResponse(
-        API_CLIENT.adminController.fetchPublishers({
-          page,
-          size: 20,
-        })
-      );
+      const response = await API_CLIENT.adminController.fetchPublishers({
+        page,
+        size: 20,
+      });
       if (!response.isSuccessful) {
         throw new Error(response.errorMessage);
       }
@@ -145,12 +143,10 @@ function PendingPublisherCard() {
   } = useQuery({
     queryKey: ["publisherApplications", page],
     queryFn: async () => {
-      const response = await wrapApiResponse(
-        API_CLIENT.adminController.fetchPendingList({
-          page,
-          size: 10,
-        })
-      );
+      const response = await API_CLIENT.adminController.fetchPendingList({
+        page,
+        size: 10,
+      });
       if (!response.isSuccessful) {
         throw new Error(response.errorMessage);
       }
@@ -161,9 +157,7 @@ function PendingPublisherCard() {
   });
 
   const onApproveButtonClicked = async (id: number) => {
-    const response = await wrapApiResponse(
-      API_CLIENT.adminController.acceptPublisher(id)
-    );
+    const response = await API_CLIENT.adminController.acceptPublisher(id);
 
     if (!response.isSuccessful) {
       console.error(response.errorMessage);
@@ -293,10 +287,11 @@ function RejectPublisherModal(props: {
 
   const onRejectButtonClicked = async () => {
     if (!publisherId) return;
-    const response = await wrapApiResponse(
-      API_CLIENT.adminController.rejectPublisher(publisherId, {
+    const response = await API_CLIENT.adminController.rejectPublisher(
+      publisherId,
+      {
         reason,
-      })
+      }
     );
     if (!response.isSuccessful) {
       console.error(response.errorMessage);

--- a/client/src/routes/_pathlessLayout/admin/uploadBook.tsx
+++ b/client/src/routes/_pathlessLayout/admin/uploadBook.tsx
@@ -12,7 +12,7 @@ import {
 } from "@mui/material";
 import { createFileRoute } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
-import API_CLIENT, { wrapApiResponse } from "../../../api/api";
+import API_CLIENT from "../../../api/api";
 import { Add } from "@mui/icons-material";
 
 const MAX_DESCRIPTION_LENGTH = 255;
@@ -39,15 +39,13 @@ function RouteComponent() {
         alert("Please select a file to upload.");
         return;
       }
-      const response = await wrapApiResponse(
-        API_CLIENT.ebookController.uploadFile({
-          title,
-          file,
-          description,
-          author,
-          coverImageFile: coverImageFile ?? undefined,
-        })
-      );
+      const response = await API_CLIENT.ebookController.uploadFile({
+        title,
+        file,
+        description,
+        author,
+        coverImageFile: coverImageFile ?? undefined,
+      });
       if (response.isSuccessful) {
         setTitle("");
         setAuthor("");

--- a/client/src/routes/_pathlessLayout/books/index.tsx
+++ b/client/src/routes/_pathlessLayout/books/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
-import API_CLIENT, { wrapApiResponse } from "../../../api/api";
+import API_CLIENT from "../../../api/api";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import {
   Card,
@@ -35,19 +35,15 @@ function RouteComponent() {
   const { data: books } = useQuery({
     queryKey: ["bookList", page, sort, pageSize],
     queryFn: async () => {
-      const response = await wrapApiResponse(
-        API_CLIENT.ebookController.getBooks({
-          page,
-          size: pageSize,
-          sort,
-        })
-      );
-
+      const response = await API_CLIENT.ebookController.getBooks({
+        page,
+        size: pageSize,
+        sort,
+      });
       if (response.isSuccessful) {
         setTotalPages(response.data.totalPages!);
         return response.data.content! as (BookMetadata | undefined)[];
       }
-
       throw new Error(response.errorMessage);
     },
     initialData: new Array(pageSize).fill(undefined) as (

--- a/client/src/routes/_pathlessLayout/groups/$groupId/index.tsx
+++ b/client/src/routes/_pathlessLayout/groups/$groupId/index.tsx
@@ -30,7 +30,7 @@ import {
   Timelapse,
 } from "@mui/icons-material";
 import { useQuery } from "@tanstack/react-query";
-import API_CLIENT, { wrapApiResponse } from "../../../../api/api";
+import API_CLIENT from "../../../../api/api";
 import { useState } from "react";
 import { Activity } from "../../../../types/activity";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
@@ -51,9 +51,7 @@ function RouteComponent() {
       if (isNaN(groupIdNumber)) {
         throw new Error("Invalid group ID");
       }
-      const response = await wrapApiResponse(
-        API_CLIENT.groupController.getGroup(groupIdNumber)
-      );
+      const response = await API_CLIENT.groupController.getGroup(groupIdNumber);
       if (!response.isSuccessful) {
         throw new Error(response.errorMessage);
       }
@@ -68,9 +66,8 @@ function RouteComponent() {
       alert("Invalid group ID");
       return;
     }
-    const response = await wrapApiResponse(
-      API_CLIENT.groupController.requestJoinGroup(groupIdNumber)
-    );
+    const response =
+      await API_CLIENT.groupController.requestJoinGroup(groupIdNumber);
     if (!response.isSuccessful) {
       alert(response.errorMessage);
       return;
@@ -198,11 +195,12 @@ function ActivityCard(props: { groupId: string }) {
       if (isNaN(groupIdNumber)) {
         throw new Error("INVALID_GROUP_ID");
       }
-      const response = await wrapApiResponse(
-        API_CLIENT.activityController.getAllActivities(groupIdNumber, {
+      const response = await API_CLIENT.activityController.getAllActivities(
+        groupIdNumber,
+        {
           page,
           size: 1,
-        })
+        }
       );
 
       if (!response.isSuccessful) {
@@ -344,14 +342,15 @@ function ActivityCreateModal(props: {
       alert("Invalid group ID");
       return;
     }
-    const response = await wrapApiResponse(
-      API_CLIENT.activityController.createActivity(groupIdNumber, {
+    const response = await API_CLIENT.activityController.createActivity(
+      groupIdNumber,
+      {
         // TODO: 검색후 책 정보 가져오기
         bookId: 0,
         endTime: endDate.toISOString(),
         startTime: startDate.toISOString(),
         description,
-      })
+      }
     );
     if (!response.isSuccessful) {
       alert(response.errorMessage);

--- a/client/src/routes/_pathlessLayout/groups/$groupId/manage/joinRequests.tsx
+++ b/client/src/routes/_pathlessLayout/groups/$groupId/manage/joinRequests.tsx
@@ -10,7 +10,7 @@ import {
 } from "@mui/material";
 import { createFileRoute } from "@tanstack/react-router";
 import { Cancel, Check } from "@mui/icons-material";
-import API_CLIENT, { wrapApiResponse } from "../../../../../api/api";
+import API_CLIENT from "../../../../../api/api";
 
 export const Route = createFileRoute(
   "/_pathlessLayout/groups/$groupId/manage/joinRequests"
@@ -48,11 +48,9 @@ function RouteComponent() {
   ];
 
   const handleAcceptRequest = async (request: Request) => {
-    const response = await wrapApiResponse(
-      API_CLIENT.groupController.approveJoinRequest(
-        request.groupId,
-        request.userId
-      )
+    const response = await API_CLIENT.groupController.approveJoinRequest(
+      request.groupId,
+      request.userId
     );
     if (!response.isSuccessful) {
       console.error("Failed to accept request:", response.errorMessage);

--- a/client/src/routes/_pathlessLayout/login.tsx
+++ b/client/src/routes/_pathlessLayout/login.tsx
@@ -11,7 +11,7 @@ import {
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import useLogin from "../../api/login/useLogin";
 import { useCallback, useState } from "react";
-import API_CLIENT, { wrapApiResponse } from "../../api/api";
+import API_CLIENT from "../../api/api";
 import { AuthState } from "../../states/auth";
 
 export const Route = createFileRoute("/_pathlessLayout/login")({
@@ -26,12 +26,10 @@ function RouteComponent() {
   const [password, setPassword] = useState("");
 
   const onLoginButtonClick = useCallback(async () => {
-    const response = await wrapApiResponse(
-      API_CLIENT.loginFilterController.login({
-        email,
-        password,
-      })
-    );
+    const response = await API_CLIENT.loginFilterController.login({
+      email,
+      password,
+    });
 
     if (!response.isSuccessful) {
       alert("로그인에 실패했습니다.");

--- a/client/src/routes/_pathlessLayout/register.tsx
+++ b/client/src/routes/_pathlessLayout/register.tsx
@@ -12,7 +12,7 @@ import {
 import AddIcon from "@mui/icons-material/Add";
 import { createFileRoute } from "@tanstack/react-router";
 import { useCallback, useMemo, useState } from "react";
-import API_CLIENT, { wrapApiResponse } from "../../api/api";
+import API_CLIENT from "../../api/api";
 import useLogin from "../../api/login/useLogin";
 import { AuthState } from "../../states/auth";
 
@@ -34,11 +34,10 @@ function RouteComponent() {
   const [profileImage, setProfileImage] = useState<File | null>(null);
 
   const onVerificationCodeButtonClick = useCallback(async () => {
-    const response = await wrapApiResponse(
-      API_CLIENT.emailVerificationController.sendVerificationCode({
+    const response =
+      await API_CLIENT.emailVerificationController.sendVerificationCode({
         email,
-      })
-    );
+      });
     if (response.isSuccessful) {
       alert("인증코드가 발송되었습니다.");
       setIsCodeSent(true);
@@ -48,12 +47,10 @@ function RouteComponent() {
   }, [email]);
 
   const onVerifyCodeButtonClick = useCallback(async () => {
-    const response = await wrapApiResponse(
-      API_CLIENT.emailVerificationController.verifyCode({
-        email,
-        verificationCode,
-      })
-    );
+    const response = await API_CLIENT.emailVerificationController.verifyCode({
+      email,
+      verificationCode,
+    });
     if (response.isSuccessful) {
       alert("이메일 인증이 완료되었습니다.");
       setIsVerified(true);
@@ -67,15 +64,13 @@ function RouteComponent() {
       alert("비밀번호가 일치하지 않습니다.");
       return;
     }
-    const response = await wrapApiResponse(
-      API_CLIENT.userController.userJoin({
-        nickname,
-        email,
-        password,
-        verificationCode,
-        ...(profileImage ? { profileImage } : {}),
-      })
-    );
+    const response = await API_CLIENT.userController.userJoin({
+      nickname,
+      email,
+      password,
+      verificationCode,
+      ...(profileImage ? { profileImage } : {}),
+    });
     if (response.isSuccessful) {
       alert("회원가입이 완료되었습니다.");
       const loggedInUser = response.data as AuthState.LoggedInUser;

--- a/client/src/routes/reader.$bookId.tsx
+++ b/client/src/routes/reader.$bookId.tsx
@@ -33,7 +33,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { EpubCFI, Rendition } from "epubjs";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { ReactReader } from "react-reader";
-import API_CLIENT, { wrapApiResponse } from "../api/api";
+import API_CLIENT from "../api/api";
 import {
   keepPreviousData,
   useQuery,
@@ -89,13 +89,11 @@ function RouteComponent() {
   const { data: highlights } = useQuery({
     queryKey: ["memos", spine],
     queryFn: async () => {
-      const response = await wrapApiResponse(
-        API_CLIENT.highlightController.getHighlights({
-          page: 0,
-          size: 100,
-          spine,
-        })
-      );
+      const response = await API_CLIENT.highlightController.getHighlights({
+        page: 0,
+        size: 100,
+        spine,
+      });
       if (!response.isSuccessful) {
         throw new Error(response.errorMessage);
       }
@@ -230,15 +228,15 @@ function RouteComponent() {
         onClose={() => setOpenHighlightCreationModal(false)}
         selection={selection}
         addHighlight={async ({ cfi, memo }) => {
-          const response = await wrapApiResponse(
-            API_CLIENT.highlightController.createHighlight({
+          const response = await API_CLIENT.highlightController.createHighlight(
+            {
               memo,
               cfi,
               spine,
               // TODO: use BookId and ActivityId
               bookId: 1,
               activityId: 1,
-            })
+            }
           );
 
           if (!response.isSuccessful) {

--- a/client/src/util/loadBook.ts
+++ b/client/src/util/loadBook.ts
@@ -1,4 +1,4 @@
-import API_CLIENT, { wrapApiResponse } from "../api/api";
+import API_CLIENT from "../api/api";
 class BookStorage {
   private db: Promise<IDBDatabase>;
   constructor() {
@@ -75,9 +75,8 @@ export default async function loadBook(bookId: number) {
 }
 
 async function fetchBookFromServer(bookId: number): Promise<ArrayBuffer> {
-  const downloadUrlResponse = await wrapApiResponse(
-    API_CLIENT.ebookController.downloadFile(bookId)
-  );
+  const downloadUrlResponse =
+    await API_CLIENT.ebookController.downloadFile(bookId);
   if (!downloadUrlResponse.isSuccessful) {
     throw new Error(downloadUrlResponse.errorCode);
   }

--- a/client/swaggerTemplates/http-client.ejs
+++ b/client/swaggerTemplates/http-client.ejs
@@ -1,0 +1,3 @@
+<% const { config } = it; %>
+<% /* https://github.com/acacode/swagger-typescript-api/tree/main/templates/base/http-clients/ */ %>
+<%~ includeFile(`./http-clients/${config.httpClientType}-http-client`, it) %>

--- a/client/swaggerTemplates/http-clients/fetch-http-client.ejs
+++ b/client/swaggerTemplates/http-clients/fetch-http-client.ejs
@@ -32,6 +32,7 @@ export interface ApiConfig<SecurityDataType = unknown> {
     baseApiParams?: Omit<RequestParams, "baseUrl" | "cancelToken" | "signal">;
     securityWorker?: (securityData: SecurityDataType | null) => Promise<RequestParams | void> | RequestParams | void;
     customFetch?: typeof fetch;
+    onExpiredAccessToken?: () => void;
 }
 
 export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
@@ -48,12 +49,31 @@ export enum ContentType {
     Text = "text/plain",
 }
 
+type UnsafeApiResponseBody = {
+    isSuccessful?: boolean;
+    data?: unknown;
+    error?: unknown;
+};
+
+export type ApiResponse<D, E> =
+    | {
+            isSuccessful: true;
+            data: D;
+      }
+    | {
+            isSuccessful: false;
+            error: E;
+            errorCode: string;
+            errorMessage: string;
+      };
+
 export class HttpClient<SecurityDataType = unknown> {
     public baseUrl: string = "<%~ apiConfig.baseUrl %>";
     private securityData: SecurityDataType | null = null;
     private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
     private abortControllers = new Map<CancelToken, AbortController>();
     private customFetch = (...fetchParams: Parameters<typeof fetch>) => fetch(...fetchParams);
+    private onExpiredAccessToken?: ApiConfig<SecurityDataType>["onExpiredAccessToken"];
 
     private baseApiParams: RequestParams = {
         credentials: 'same-origin',
@@ -171,7 +191,11 @@ export class HttpClient<SecurityDataType = unknown> {
         }
     }
 
-    public request = async <T = any, E = any>({
+    public request = async <
+        T = any,
+        E = any,
+        R = ApiResponse<NonNullable<T["data"]>, E>,
+    >({
         body,
         secure,
         path,
@@ -184,7 +208,7 @@ export class HttpClient<SecurityDataType = unknown> {
 <% if (config.unwrapResponseData) { %>
     }: FullRequestParams): Promise<T> => {
 <% } else { %>
-    }: FullRequestParams): Promise<HttpResponse<T, E>> => {
+    }: FullRequestParams): Promise<R> => {
 <% } %>
         const secureParams = ((typeof secure === 'boolean' ? secure : this.baseApiParams.secure) && this.securityWorker && await this.securityWorker(this.securityData)) || {};
         const requestParams = this.mergeRequestParams(params, secureParams);
@@ -205,35 +229,33 @@ export class HttpClient<SecurityDataType = unknown> {
         }
         ).then(async (response) => {
             const r = response.clone() as HttpResponse<T, E>;
-            r.data = (null as unknown) as T;
-            r.error = (null as unknown) as E;
+            r.data = null as unknown as T;
+            r.error = null as unknown as E;
 
-            const data = !responseFormat ? r : await response[responseFormat]()
+            const data = await response[responseFormat || "json"]()
                 .then((data) => {
-                    if (r.ok) {
-                        r.data = data;
-                    } else {
-                        r.error = data;
-                    }
-                    return r;
+                    return data as R;
                 })
-                .catch((e) => {
-                    r.error = e;
-                    return r;
+                .catch((error) => {
+                    return {
+                        isSuccessful: false,
+                        error: error,
+                        errorCode: "UNKNOWN_ERROR",
+                        errorMessage: "Unknown error occurred",
+                    } as R;
                 });
+
+            if (!data.isSuccessful) {
+                if (data.errorCode === "EXPIRED_ACCESS_TOKEN") {
+                    this.onExpiredAccessToken();
+                }
+            }
 
             if (cancelToken) {
                 this.abortControllers.delete(cancelToken);
             }
 
-<% if (!config.disableThrowOnError) { %>
-            if (!response.ok) throw data;
-<% } %>
-<% if (config.unwrapResponseData) { %>
-            return data.data;
-<% } else { %>
             return data;
-<% } %>
         });
     };
 }

--- a/client/swaggerTemplates/http-clients/fetch-http-client.ejs
+++ b/client/swaggerTemplates/http-clients/fetch-http-client.ejs
@@ -1,0 +1,239 @@
+<%
+const { apiConfig, generateResponses, config } = it;
+%>
+
+export type QueryParamsType = Record<string | number, any>;
+export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">;
+
+export interface FullRequestParams extends Omit<RequestInit, "body"> {
+  /** set parameter to `true` for call `securityWorker` for this request */
+  secure?: boolean;
+  /** request path */
+  path: string;
+  /** content type of request body */
+  type?: ContentType;
+  /** query params */
+  query?: QueryParamsType;
+  /** format of response (i.e. response.json() -> format: "json") */
+  format?: ResponseFormat;
+  /** request body */
+  body?: unknown;
+  /** base url */
+  baseUrl?: string;
+  /** request cancellation token */
+  cancelToken?: CancelToken;
+}
+
+export type RequestParams = Omit<FullRequestParams, "body" | "method" | "query" | "path">
+
+
+export interface ApiConfig<SecurityDataType = unknown> {
+    baseUrl?: string;
+    baseApiParams?: Omit<RequestParams, "baseUrl" | "cancelToken" | "signal">;
+    securityWorker?: (securityData: SecurityDataType | null) => Promise<RequestParams | void> | RequestParams | void;
+    customFetch?: typeof fetch;
+}
+
+export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+    data: D;
+    error: E;
+}
+
+type CancelToken = Symbol | string | number;
+
+export enum ContentType {
+    Json = "application/json",
+    FormData = "multipart/form-data",
+    UrlEncoded = "application/x-www-form-urlencoded",
+    Text = "text/plain",
+}
+
+export class HttpClient<SecurityDataType = unknown> {
+    public baseUrl: string = "<%~ apiConfig.baseUrl %>";
+    private securityData: SecurityDataType | null = null;
+    private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
+    private abortControllers = new Map<CancelToken, AbortController>();
+    private customFetch = (...fetchParams: Parameters<typeof fetch>) => fetch(...fetchParams);
+
+    private baseApiParams: RequestParams = {
+        credentials: 'same-origin',
+        headers: {},
+        redirect: 'follow',
+        referrerPolicy: 'no-referrer',
+    }
+
+    constructor(apiConfig: ApiConfig<SecurityDataType> = {}) {
+        Object.assign(this, apiConfig);
+    }
+
+    public setSecurityData = (data: SecurityDataType | null) => {
+        this.securityData = data;
+    }
+
+    protected encodeQueryParam(key: string, value: any) {
+        const encodedKey = encodeURIComponent(key);
+        return `${encodedKey}=${encodeURIComponent(typeof value === "number" ? value : `${value}`)}`;
+    }
+
+    protected addQueryParam(query: QueryParamsType, key: string) {
+        return this.encodeQueryParam(key, query[key]);
+    }
+
+    protected addArrayQueryParam(query: QueryParamsType, key: string) {
+        const value = query[key];
+        return value.map((v: any) => this.encodeQueryParam(key, v)).join("&");
+    }
+
+    protected toQueryString(rawQuery?: QueryParamsType): string {
+        const query = rawQuery || {};
+        const keys = Object.keys(query).filter((key) => "undefined" !== typeof query[key]);
+        return keys
+                .map((key) =>
+                    Array.isArray(query[key])
+                    ? this.addArrayQueryParam(query, key)
+                    : this.addQueryParam(query, key),
+                )
+                .join("&");
+    }
+
+    protected addQueryParams(rawQuery?: QueryParamsType): string {
+        const queryString = this.toQueryString(rawQuery);
+        return queryString ? `?${queryString}` : "";
+    }
+
+    private contentFormatters: Record<ContentType, (input: any) => any> = {
+        [ContentType.Json]: (input:any) => input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
+        [ContentType.Text]: (input:any) => input !== null && typeof input !== "string" ? JSON.stringify(input) : input,
+        [ContentType.FormData]: (input: any) =>
+            Object.keys(input || {}).reduce((formData, key) => {
+                const property = input[key];
+                if (property === undefined || property === null) {
+                    return formData;
+                }
+                if (property instanceof Blob) {
+                    formData.append(key, property);
+                    return formData;
+                }
+                if (property instanceof Array) {
+                    return property.reduce((formData, property) => {
+                        formData.append(key, `${property}`);
+                        return formData;
+                    }, formData);
+                }
+                if (typeof property === "object" && property !== null) {
+                    formData.append(key, JSON.stringify(property));
+                    return formData;
+                }
+                if (typeof property === "number" || typeof property === "string") {
+                    formData.append(key, `${property}`);
+                    return formData;
+                }
+                throw new Error(
+                    `The request body property "${key}" is not a valid type.`
+                );
+            }, new FormData()),
+        [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),
+    }
+
+    protected mergeRequestParams(params1: RequestParams, params2?: RequestParams): RequestParams {
+        return {
+            ...this.baseApiParams,
+            ...params1,
+            ...(params2 || {}),
+            headers: {
+                ...(this.baseApiParams.headers || {}),
+                ...(params1.headers || {}),
+                ...((params2 && params2.headers) || {}),
+            },
+        };
+    }
+
+    protected createAbortSignal = (cancelToken: CancelToken): AbortSignal | undefined => {
+        if (this.abortControllers.has(cancelToken)) {
+            const abortController = this.abortControllers.get(cancelToken);
+            if (abortController) {
+                return abortController.signal;
+            }
+            return void 0;
+        }
+
+        const abortController = new AbortController();
+        this.abortControllers.set(cancelToken, abortController);
+        return abortController.signal;
+    }
+
+    public abortRequest = (cancelToken: CancelToken) => {
+        const abortController = this.abortControllers.get(cancelToken)
+
+        if (abortController) {
+            abortController.abort();
+            this.abortControllers.delete(cancelToken);
+        }
+    }
+
+    public request = async <T = any, E = any>({
+        body,
+        secure,
+        path,
+        type,
+        query,
+        format,
+        baseUrl,
+        cancelToken,
+        ...params
+<% if (config.unwrapResponseData) { %>
+    }: FullRequestParams): Promise<T> => {
+<% } else { %>
+    }: FullRequestParams): Promise<HttpResponse<T, E>> => {
+<% } %>
+        const secureParams = ((typeof secure === 'boolean' ? secure : this.baseApiParams.secure) && this.securityWorker && await this.securityWorker(this.securityData)) || {};
+        const requestParams = this.mergeRequestParams(params, secureParams);
+        const queryString = query && this.toQueryString(query);
+        const payloadFormatter = this.contentFormatters[type || ContentType.Json];
+        const responseFormat = format || requestParams.format;
+
+        return this.customFetch(
+        `${baseUrl || this.baseUrl || ""}${path}${queryString ? `?${queryString}` : ""}`,
+        {
+            ...requestParams,
+            headers: {
+            ...(requestParams.headers || {}),
+            ...(type && type !== ContentType.FormData ? { "Content-Type": type } : {}),
+            },
+            signal: (cancelToken ? this.createAbortSignal(cancelToken) : requestParams.signal) || null,
+            body: typeof body === "undefined" || body === null ? null : payloadFormatter(body),
+        }
+        ).then(async (response) => {
+            const r = response.clone() as HttpResponse<T, E>;
+            r.data = (null as unknown) as T;
+            r.error = (null as unknown) as E;
+
+            const data = !responseFormat ? r : await response[responseFormat]()
+                .then((data) => {
+                    if (r.ok) {
+                        r.data = data;
+                    } else {
+                        r.error = data;
+                    }
+                    return r;
+                })
+                .catch((e) => {
+                    r.error = e;
+                    return r;
+                });
+
+            if (cancelToken) {
+                this.abortControllers.delete(cancelToken);
+            }
+
+<% if (!config.disableThrowOnError) { %>
+            if (!response.ok) throw data;
+<% } %>
+<% if (config.unwrapResponseData) { %>
+            return data.data;
+<% } else { %>
+            return data;
+<% } %>
+        });
+    };
+}


### PR DESCRIPTION
## ✨ 작업 개요
API 클라이언트 수정

## ✅ 작업 내용
- API 클라이언트 커스텀
- 폼데이터
  - array형식을 보낼 때 multipart로 구성
  - 빈 필드는 스킵
- wrapApiResponse를 클라이언트에 병합

## 📎 관련 이슈

## 🧪 테스트 방법

## 💬 기타
@P4NTENG 이제 wrapApiResponse()를 사용하지 않아도 됩니다
