### PR TITLE
[TASK 4-3-4][FE] 모임지기용 모임원 관리 페이지 UI

### DIFF
--- a/client/src/component/SideNavigatorBar.tsx
+++ b/client/src/component/SideNavigatorBar.tsx
@@ -42,7 +42,7 @@ export default function SideNavigationBar(props: {
         </ListItem>
         {items.map(({ to, icon, label, disableShowActive }) => {
           return (
-            <LinkListItem disablePadding to={to}>
+            <LinkListItem disablePadding to={to} key={to}>
               {({ isActive }) => {
                 return (
                   <ListItemButton

--- a/client/src/routes/_pathlessLayout/groups/$groupId/manage/member.tsx
+++ b/client/src/routes/_pathlessLayout/groups/$groupId/manage/member.tsx
@@ -1,4 +1,5 @@
 import {
+  Avatar,
   Button,
   Card,
   CardContent,
@@ -143,6 +144,7 @@ function PendingMemberCard() {
                             spacing={1}
                             alignItems={"center"}
                           >
+                            <Avatar src={pending.profileImageURL} />
                             <Typography>{pending.nickname}</Typography>
                           </Stack>
                         </TableCell>
@@ -197,8 +199,7 @@ function MembersCard() {
       if (isNaN(groupIdNumber)) {
         throw new Error("Invalid group ID");
       }
-      // TODO: Fetch members
-      const response = await API_CLIENT.groupController.getPendingList(
+      const response = await API_CLIENT.groupController.getGroupMembers(
         groupIdNumber,
         {
           page,
@@ -230,6 +231,8 @@ function MembersCard() {
                 <TableRow>
                   <TableCell>ID</TableCell>
                   <TableCell>닉네임</TableCell>
+                  <TableCell>가입 신청일</TableCell>
+                  <TableCell>승인일</TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>
@@ -237,21 +240,33 @@ function MembersCard() {
                   pendingRequests.length === 0 ? (
                     <TableRow>
                       <TableCell colSpan={7} align="center">
-                        대기 중인 신청이 없습니다.
+                        모임원이 없습니다
                       </TableCell>
                     </TableRow>
                   ) : (
-                    pendingRequests.map((pending) => (
-                      <TableRow key={pending.userId}>
-                        <TableCell>{pending.userId}</TableCell>
+                    pendingRequests.map((member) => (
+                      <TableRow key={member.userId}>
+                        <TableCell>{member.userId}</TableCell>
                         <TableCell>
                           <Stack
                             direction={"row"}
                             spacing={1}
                             alignItems={"center"}
                           >
-                            <Typography>{pending.nickname}</Typography>
+                            <Avatar src={member.profileImageURL} />
+                            <Typography>{member.nickname}</Typography>
                           </Stack>
+                        </TableCell>
+
+                        <TableCell>
+                          {member.createdAt
+                            ? new Date(member.createdAt).toLocaleString()
+                            : "-"}
+                        </TableCell>
+                        <TableCell>
+                          {member.approvedAt
+                            ? new Date(member.approvedAt).toLocaleString()
+                            : "-"}
                         </TableCell>
                       </TableRow>
                     ))

--- a/client/src/routes/_pathlessLayout/groups/$groupId/manage/route.tsx
+++ b/client/src/routes/_pathlessLayout/groups/$groupId/manage/route.tsx
@@ -1,7 +1,7 @@
 import { Box, Container } from "@mui/material";
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 import SideNavigationBar from "../../../../../component/SideNavigatorBar";
-import { Assignment, Home } from "@mui/icons-material";
+import { Home, People } from "@mui/icons-material";
 
 export const Route = createFileRoute("/_pathlessLayout/groups/$groupId/manage")(
   {
@@ -21,9 +21,9 @@ function RouteComponent() {
             disableShowActive: true,
           },
           {
-            to: "/groups/$groupId/manage/joinRequests",
-            icon: <Assignment />,
-            label: "가입대기",
+            to: "/groups/$groupId/manage/member",
+            icon: <People />,
+            label: "모임원",
           },
         ]}
       />


### PR DESCRIPTION
## ✨ 작업 개요
 모임지기용 모임원 관리 페이지

## ✅ 작업 내용
- 모임 가입 신청 승인/거절 API 사용
- 모임원 목록 표

![image](https://github.com/user-attachments/assets/fc692d4f-47c9-4a04-9489-2dc132b3194f)


## 📎 관련 이슈
Closes #61 
#60 에 의존

## 🧪 테스트 방법

## 💬 기타
승인/거절 API의 응답은 성공이나 실제로 반영되지는 않음