### PR TITLE
[FEAT][BE] 더미 데이터 자동 생성 기능 구현

### DIFF
--- a/chaekit-spring/src/main/java/qwerty/chaekit/controller/ebook/EbookController.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/controller/ebook/EbookController.java
@@ -41,7 +41,7 @@ public class EbookController {
     @GetMapping("/{ebookId}")
     @Operation(summary = "전자책 상세 조회", description = "전자책의 상세 정보를 조회합니다.")
     public ApiSuccessResponse<EbookFetchResponse> getBook(
-            @Parameter(hidden = true) @Login UserToken userToken,
+            @Parameter(hidden = true) @Login(required = false) UserToken userToken,
             @Parameter(description = "조회할 전자책 ID") @PathVariable Long ebookId
     ) {
         return ApiSuccessResponse.of(ebookService.fetchById(userToken, ebookId));

--- a/chaekit-spring/src/main/java/qwerty/chaekit/controller/highlight/HighlightController.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/controller/highlight/HighlightController.java
@@ -1,6 +1,7 @@
 package qwerty.chaekit.controller.highlight;
 
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
@@ -43,7 +44,7 @@ public class HighlightController {
     }
 
     @PostMapping
-    public ApiSuccessResponse<HighlightPostResponse> createHighlight(@Login UserToken userToken, @RequestBody HighlightPostRequest request) {
+    public ApiSuccessResponse<HighlightPostResponse> createHighlight(@Login UserToken userToken, @RequestBody @Valid HighlightPostRequest request) {
         return ApiSuccessResponse.of(highlightService.createHighlight(userToken, request));
     }
 

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/ebook/repository/EbookJpaRepository.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/ebook/repository/EbookJpaRepository.java
@@ -11,4 +11,6 @@ import java.util.Optional;
 public interface EbookJpaRepository extends JpaRepository<Ebook, Long> {
     @Query("SELECT e FROM Ebook e LEFT JOIN FETCH e.publisher WHERE e.id = :id")
     Optional<Ebook> findByIdWithPublisher(Long id);
+    
+    boolean existsByTitle(String title);
 } 

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/ebook/repository/EbookRepository.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/ebook/repository/EbookRepository.java
@@ -13,6 +13,5 @@ public interface EbookRepository {
     Optional<Ebook> findById(Long id);
     Optional<Ebook> findByIdWithPublisher(Long id);
     Ebook save(Ebook ebook);
-    boolean existsById(Long id);
-    Ebook getReferenceById(Long id);
+    boolean existsByTitle(String title);
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/ebook/repository/EbookRepositoryImpl.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/ebook/repository/EbookRepositoryImpl.java
@@ -63,12 +63,8 @@ public class EbookRepositoryImpl implements EbookRepository {
     }
 
     @Override
-    public boolean existsById(Long id) {
-        return ebookJpaRepository.existsById(id);
+    public boolean existsByTitle(String name) {
+        return ebookJpaRepository.existsByTitle(name);
     }
-
-    @Override
-    public Ebook getReferenceById(Long id) {
-        return ebookJpaRepository.getReferenceById(id);
-    }
+    
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/highlight/entity/Highlight.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/highlight/entity/Highlight.java
@@ -34,7 +34,7 @@ public class Highlight extends BaseEntity {
     @Column(nullable = false)
     private String spine;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 1000)
     private String highlightcontent;
   
     @Column(length = 2000)

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/ebook/upload/EbookPostRequest.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/ebook/upload/EbookPostRequest.java
@@ -3,18 +3,22 @@ package qwerty.chaekit.dto.ebook.upload;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Length;
 import org.springframework.web.multipart.MultipartFile;
 
 public record EbookPostRequest(
         @Schema(description = "책 제목", example = "이상한 나라의 앨리스")
         @NotBlank
+        @Length(max=255)
         String title,
 
         @Schema(description = "책 저자", example = "루이스 캐럴")
         @NotBlank
+        @Length(max=50)
         String author,
 
         @Schema(description = "책 설명", example = "《이상한 나라의 앨리스》는 영국의 수학자이자 작가인 찰스 루트위지 도지슨이 루이스 캐럴이라는 필명으로 1865년에 발표한 소설이다.")
+        @Length(max=10000)
         String description,
 
         @Schema(description = "책 파일", example = "Alice.epub", type = "string", format = "binary")

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/ActivityPatchRequest.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/ActivityPatchRequest.java
@@ -2,6 +2,7 @@ package qwerty.chaekit.dto.group.activity;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
+import org.hibernate.validator.constraints.Length;
 
 import java.time.LocalDate;
 
@@ -11,5 +12,6 @@ public record ActivityPatchRequest(
         Long activityId,
         LocalDate startTime,
         LocalDate endTime,
+        @Length(max = 5000)
         String description
 ) { }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/ActivityPostRequest.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/ActivityPostRequest.java
@@ -3,6 +3,7 @@ package qwerty.chaekit.dto.group.activity;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
+import org.hibernate.validator.constraints.Length;
 
 import java.time.LocalDate;
 
@@ -15,5 +16,6 @@ public record ActivityPostRequest(
         @NotNull
         LocalDate endTime,
         @Nullable
+        @Length(max = 5000)
         String description
 ) { }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionCommentPatchRequest.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionCommentPatchRequest.java
@@ -1,8 +1,10 @@
 package qwerty.chaekit.dto.group.activity.discussion;
 
 import lombok.NonNull;
+import org.hibernate.validator.constraints.Length;
 
 public record DiscussionCommentPatchRequest(
+        @Length(max = 1000)
         @NonNull String content
 ) {
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionCommentPostRequest.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionCommentPostRequest.java
@@ -2,11 +2,13 @@ package qwerty.chaekit.dto.group.activity.discussion;
 
 
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Length;
 import qwerty.chaekit.domain.group.activity.discussion.DiscussionStance;
 
 public record DiscussionCommentPostRequest(
         Long parentId,
         @NotNull
+        @Length(max = 1000)
         String content,
         @NotNull
         DiscussionStance stance

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionPatchRequest.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionPatchRequest.java
@@ -1,9 +1,13 @@
 package qwerty.chaekit.dto.group.activity.discussion;
 
+import org.hibernate.validator.constraints.Length;
+
 import java.util.List;
 
 public record DiscussionPatchRequest(
+        @Length(max = 100)
         String title,
+        @Length(max = 5000)
         String content,
         List<Long> highlightIds
 ) { }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionPostRequest.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/activity/discussion/DiscussionPostRequest.java
@@ -2,13 +2,16 @@ package qwerty.chaekit.dto.group.activity.discussion;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Length;
 
 import java.util.List;
 
 public record DiscussionPostRequest(
         @NotBlank
+        @Length(max = 100)
         String title,
         @NotBlank
+        @Length(max = 5000)
         String content,
         @NotNull
         Boolean isDebate,

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/request/GroupPatchRequest.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/request/GroupPatchRequest.java
@@ -1,8 +1,10 @@
 package qwerty.chaekit.dto.group.request;
 
+import org.hibernate.validator.constraints.Length;
 import org.springframework.web.multipart.MultipartFile;
 
 public record GroupPatchRequest(
+        @Length(max = 5000)
         String description,
         MultipartFile groupImage
 ) { }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/request/GroupPostRequest.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/request/GroupPostRequest.java
@@ -1,14 +1,17 @@
 package qwerty.chaekit.dto.group.request;
 
 import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.Length;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 public record GroupPostRequest(
         @NotBlank
+        @Length(max = 50)
         String name,
         @NotBlank
+        @Length(max = 5000)
         String description,
         List<String> tags,
         MultipartFile groupImage

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/highlight/HighlightPostRequest.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/highlight/HighlightPostRequest.java
@@ -1,6 +1,7 @@
 package qwerty.chaekit.dto.highlight;
 
 import lombok.Builder;
+import org.hibernate.validator.constraints.Length;
 
 @Builder
 public record HighlightPostRequest(
@@ -8,6 +9,8 @@ public record HighlightPostRequest(
         String spine,
         String cfi,
         Long activityId,
+        @Length(max = 1000)
         String memo,
+        @Length(max = 500)
         String highlightContent
 ) { }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/highlight/comment/HighlightCommentRequest.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/highlight/comment/HighlightCommentRequest.java
@@ -1,7 +1,10 @@
 package qwerty.chaekit.dto.highlight.comment;
 
+import org.hibernate.validator.constraints.Length;
+
 public record HighlightCommentRequest(
-    String content,
-    Long parentId
+        @Length(max = 1000) 
+        String content, 
+        Long parentId
 ) {
 } 

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/init/AdminInitializer.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/init/AdminInitializer.java
@@ -72,6 +72,7 @@ public class AdminInitializer implements ApplicationRunner {
                     UserProfile.builder()
                             .member(adminMember)
                             .nickname(adminName)
+                            .profileImageKey("profile-image/logo.png")
                             .build()
             );
             log.info("관리자 사용자 프로필이 추가되었습니다.");

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/init/DummyDataInitializer.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/init/DummyDataInitializer.java
@@ -8,16 +8,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-import qwerty.chaekit.domain.ebook.credit.wallet.CreditWallet;
-import qwerty.chaekit.domain.ebook.credit.wallet.CreditWalletRepository;
-import qwerty.chaekit.domain.member.Member;
-import qwerty.chaekit.domain.member.MemberRepository;
-import qwerty.chaekit.domain.member.enums.Role;
-import qwerty.chaekit.domain.member.publisher.PublisherProfile;
-import qwerty.chaekit.domain.member.publisher.PublisherProfileRepository;
 import qwerty.chaekit.domain.member.user.UserProfile;
-import qwerty.chaekit.domain.member.user.UserProfileRepository;
-import qwerty.chaekit.service.member.MemberJoinHelper;
 
 @Slf4j
 @Component
@@ -25,74 +16,18 @@ import qwerty.chaekit.service.member.MemberJoinHelper;
 @Profile(value = {"local", "dev"})
 @Order(2)
 public class DummyDataInitializer implements ApplicationRunner {
-    private final MemberJoinHelper memberJoinHelper;
-    private final PublisherProfileRepository publisherProfileRepository;
-    private final MemberRepository memberRepository;
-    private final UserProfileRepository userProfileRepository;
-
-    private final String defaultPassword = "0000";
-    private final CreditWalletRepository creditWalletRepository;
+    private final DummyUserFactory dummyUserFactory;
+    private final DummyPublisherFactory dummyPublisherFactory;
+    private final DummyEbookFactory dummyEbookFactory;
+    private final DummyGroupFactory dummyGroupFactory;
 
     @Override
     @Transactional
     public void run(ApplicationArguments args) {
-        log.info("Try to create dummy data...");
-        createDummyUsers();
-        createDummyPublishers();
-    }
-
-    private void createDummyUsers() {
-        for (int i = 1; i <= 3; i++) {
-            String userEmail = getDummyUserEmail(i);
-            if (memberRepository.existsByEmail(userEmail)) {
-                continue;
-            }
-            Member userMember = memberJoinHelper.saveMember(userEmail, defaultPassword, Role.ROLE_USER);
-            UserProfile savedUser = userProfileRepository.save(
-                    UserProfile.builder()
-                            .member(userMember)
-                            .nickname(getDummyNickname(i))
-                            .build()
-            );
-            creditWalletRepository.save(
-                    CreditWallet.builder()
-                            .user(savedUser)
-                            .build()
-            );
-            log.info("Created user profile: {}", userEmail);
-        }
-    }
-
-    private void createDummyPublishers() {
-        for (int i = 1; i <= 3; i++) {
-            String publisherEmail = getDummyPublisherEmail(i);
-            if (memberRepository.existsByEmail(publisherEmail)) {
-                continue;
-            }
-            Member publisherMember = memberJoinHelper.saveMember(publisherEmail, defaultPassword, Role.ROLE_PUBLISHER);
-            publisherProfileRepository.save(
-                    PublisherProfile.builder()
-                            .member(publisherMember)
-                            .publisherName(getDummyPublisherName(i))
-                            .build()
-            );
-            log.info("Created publisher profile: {}", publisherEmail);
-        }
-    }
-
-    private static String getDummyUserEmail(int index) {
-        return "user" + index + "@example.com";
-    }
-
-    private static String getDummyPublisherEmail(int index) {
-        return "publisher" + index + "@example.com";
-    }
-
-    private static String getDummyNickname(int index) {
-        return "test_user" + index;
-    }
-
-    private static String getDummyPublisherName(int index) {
-        return "test_publisher" + index;
+        log.info("더미 데이터를 생성을 시도합니다.");
+        UserProfile leader = dummyUserFactory.saveDummyUsers();
+        dummyPublisherFactory.saveDummyPublishers();
+        dummyEbookFactory.saveDummyEbooks();
+        dummyGroupFactory.saveDummyGroups(leader);
     }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/init/DummyEbookFactory.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/init/DummyEbookFactory.java
@@ -1,0 +1,50 @@
+package qwerty.chaekit.global.init;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import qwerty.chaekit.domain.ebook.Ebook;
+import qwerty.chaekit.domain.ebook.repository.EbookRepository;
+import qwerty.chaekit.domain.member.publisher.PublisherProfile;
+import qwerty.chaekit.global.init.dummy.DummyEbook;
+import qwerty.chaekit.service.member.admin.AdminService;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DummyEbookFactory {
+    private final EbookRepository ebookRepository;
+    private final AdminService adminService;
+    
+    public void saveDummyEbooks() {
+        saveDummyEbook(DummyEbook.ALICE);
+        saveDummyEbook(DummyEbook.ROMEO_AND_JULIET);
+        saveDummyEbook(DummyEbook.MOBY_D);
+        saveDummyEbook(DummyEbook.CINDERELLA);
+        saveDummyEbook(DummyEbook.FRANKENSTEIN);
+    }
+
+    private void saveDummyEbook(DummyEbook ebookData) {
+        if (ebookRepository.existsByTitle(ebookData.getTitle())) {
+            log.info("\"{}\"이 이미 존재합니다.", ebookData.getTitle());
+            return;
+        }
+        Ebook ebook = toEbook(ebookData);
+        ebookRepository.save(ebook);
+        log.info("\"{}\"이 새로 생성되었습니다.", ebookData.getTitle());
+    }
+
+    private Ebook toEbook(DummyEbook ebookData) {
+        return Ebook.builder()
+                .title(ebookData.getTitle())
+                .author(ebookData.getAuthor())
+                .publisher(PublisherProfile.builder().id(adminService.getAdminPublisherId()).build())
+                .description(ebookData.getDescription())
+                .fileKey(ebookData.getFileKey())
+                .coverImageKey(ebookData.getCoverImageKey())
+                .size(ebookData.getSize())
+                .price(ebookData.getPrice())
+                .build();
+    }
+    
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/init/DummyGroupFactory.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/init/DummyGroupFactory.java
@@ -1,0 +1,32 @@
+package qwerty.chaekit.global.init;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import qwerty.chaekit.domain.group.ReadingGroup;
+import qwerty.chaekit.domain.group.repository.GroupRepository;
+import qwerty.chaekit.domain.member.user.UserProfile;
+import qwerty.chaekit.global.init.dummy.DummyGroup;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DummyGroupFactory {
+    private final GroupRepository groupRepository;
+
+    public void saveDummyGroups(UserProfile leader) {
+        DummyGroup dummyPublisher = DummyGroup.CLASSIC;
+        ReadingGroup dummyGroup = ReadingGroup.builder()
+                .name(dummyPublisher.getName())
+                .groupLeader(leader)
+                .description(dummyPublisher.getDescription())
+                .groupImageKey(dummyPublisher.getGroupImageKey())
+                .build();
+        
+        if(!groupRepository.existsReadingGroupByName(dummyGroup.getName())) {
+            ReadingGroup savedGroup = groupRepository.save(dummyGroup);
+            savedGroup.addMember(leader).approve();
+            log.info("독서 모임\"{}\"이 새로 생성되었습니다.", dummyGroup.getName());
+        }
+    }
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/init/DummyPublisherFactory.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/init/DummyPublisherFactory.java
@@ -1,0 +1,48 @@
+package qwerty.chaekit.global.init;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import qwerty.chaekit.domain.member.Member;
+import qwerty.chaekit.domain.member.MemberRepository;
+import qwerty.chaekit.domain.member.enums.Role;
+import qwerty.chaekit.domain.member.publisher.PublisherProfile;
+import qwerty.chaekit.domain.member.publisher.PublisherProfileRepository;
+import qwerty.chaekit.global.init.dummy.DummyPublisher;
+import qwerty.chaekit.service.member.MemberJoinHelper;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DummyPublisherFactory {
+    private final MemberRepository memberRepository;
+    private final PublisherProfileRepository publisherProfileRepository;
+    private final MemberJoinHelper memberJoinHelper;
+    
+    public void saveDummyPublishers() {
+        for (DummyPublisher dummyPublisher : DummyPublisher.values()) {
+            saveDummyPublisher(dummyPublisher);
+        }
+    }
+    
+    public void saveDummyPublisher(DummyPublisher publisherSample) {
+        String email = publisherSample.getEmail();
+        String publisherName = publisherSample.getPublisherName();
+        String profileImageKey = publisherSample.getProfileImageKey();
+        String defaultPassword = "0000";
+        if (memberRepository.existsByEmail(email)) {
+            return;
+        }
+
+        Member publisherMember = memberJoinHelper.saveMember(email, defaultPassword, Role.ROLE_PUBLISHER);
+        publisherProfileRepository.save(
+                PublisherProfile.builder()
+                        .member(publisherMember)
+                        .publisherName(publisherName)
+                        .profileImageKey(profileImageKey)
+                        .build()
+        );
+        
+        log.info("출판사 \"{}\"가 생성되었습니다.", publisherName);
+    }
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/init/DummyUserFactory.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/init/DummyUserFactory.java
@@ -1,0 +1,59 @@
+package qwerty.chaekit.global.init;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import qwerty.chaekit.domain.ebook.credit.wallet.CreditWallet;
+import qwerty.chaekit.domain.ebook.credit.wallet.CreditWalletRepository;
+import qwerty.chaekit.domain.member.Member;
+import qwerty.chaekit.domain.member.MemberRepository;
+import qwerty.chaekit.domain.member.enums.Role;
+import qwerty.chaekit.domain.member.user.UserProfile;
+import qwerty.chaekit.domain.member.user.UserProfileRepository;
+import qwerty.chaekit.global.init.dummy.DummyUser;
+import qwerty.chaekit.service.member.MemberJoinHelper;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DummyUserFactory {
+    private final MemberRepository memberRepository;
+    private final UserProfileRepository userProfileRepository;
+    private final MemberJoinHelper memberJoinHelper;
+    private final CreditWalletRepository creditWalletRepository;
+    
+    public UserProfile saveDummyUsers() {
+        UserProfile leader = saveDummyUser(DummyUser.LEADER);
+        saveDummyUser(DummyUser.USER1);
+        saveDummyUser(DummyUser.USER2);
+        saveDummyUser(DummyUser.USER3);
+        return leader;
+    }
+    
+    public UserProfile saveDummyUser(DummyUser dummyUser) {
+        String email = dummyUser.getEmail();
+        String nickname = dummyUser.getNickname();
+        String profileImageKey = dummyUser.getProfileImageKey();
+        String defaultPassword = "0000";
+        if (memberRepository.existsByEmail(email)) {
+            return null;
+        }
+
+        Member userMember = memberJoinHelper.saveMember(email, defaultPassword, Role.ROLE_USER);
+        UserProfile savedUser = userProfileRepository.save(
+                UserProfile.builder()
+                        .member(userMember)
+                        .nickname(nickname)
+                        .profileImageKey(profileImageKey)
+                        .build()
+        );
+        creditWalletRepository.save(
+                CreditWallet.builder()
+                        .user(savedUser)
+                        .build()
+        );
+        
+        log.info("유저 \"{}\"가 생성되었습니다.", nickname);
+        return savedUser;
+    }
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/init/dummy/DummyEbook.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/init/dummy/DummyEbook.java
@@ -1,0 +1,76 @@
+package qwerty.chaekit.global.init.dummy;
+
+import lombok.Getter;
+
+@Getter
+public enum DummyEbook {
+    ALICE("이상한 나라의 앨리스", "루이스 캐럴", 
+                    """
+                    논리와 현실이 무너진 세계, 앨리스는 토끼를 따라 기이한 모험에 빠진다.
+                    유쾌하고도 철학적인 상상력이 가득한 고전 판타지.
+                    """,
+            "ebook/sample-alice.epub", 
+            "ebook-cover-image/cover-alice.jpg", 1914953, 0
+    ),
+    ROMEO_AND_JULIET("로미오와 줄리앳", "윌리엄 셰익스피어",
+            """
+                    사랑은 가장 순수하지만, 세상은 가장 잔혹하다.
+                    비극적인 운명 속에서 피어난 젊은 연인의 이야기.
+                    """,
+            "ebook/sample-romeo.epub",
+            "ebook-cover-image/cover-romeo.jpg", 227349, 0
+    ),
+    MOBY_D("모비딕", "허먼 멜빌",
+            """
+                    흰 고래를 쫓는 집착의 항해, 그 끝은 어디인가?
+                    인간과 자연, 운명에 대한 묵직한 질문을 던지는 대서사시.
+                    """,
+            "ebook/sample-moby-dick.epub",
+            "ebook-cover-image/cover-moby-dick.jpg", 628084, 0
+    ),
+            
+    CINDERELLA("신데렐라", "작가 미상",
+            """
+                    유리 구두와 호박 마차, 그리고 꿈을 이룬 평범한 소녀.
+                    시대를 초월해 사랑받는 대표적인 동화.
+                    """,
+            "ebook/sample-cinderella.epub",
+            "ebook-cover-image/cover-cinderella.jpg", 140789, 0
+    ),
+    FRANKENSTEIN("프랑켄슈타인", "메리 셸리",
+            """
+                    인간은 어디까지 창조할 수 있는가?
+                    과학과 윤리, 외로움과 책임이 교차하는 고딕 SF의 원형.
+                    """,
+            "ebook/sample-frankenstein.epub",
+            "ebook-cover-image/cover-frankenstein.jpg", 293483, 0
+            
+    ),;
+    
+    DummyEbook(
+            String title, 
+            String author, 
+            String description,
+            String fileKey,
+            String coverImageKey,
+            long size,
+            int price
+    
+    ) {
+        this.title = title;
+        this.author = author;
+        this.description = description;
+        this.fileKey = fileKey;
+        this.coverImageKey = coverImageKey;
+        this.size = size;
+        this.price = price;
+    }
+    
+    private final String title;
+    private final String author;
+    private final String description;
+    private final String fileKey;
+    private final String coverImageKey;
+    private final long size;
+    private final int price;
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/init/dummy/DummyGroup.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/init/dummy/DummyGroup.java
@@ -1,0 +1,38 @@
+package qwerty.chaekit.global.init.dummy;
+
+import lombok.Getter;
+
+@Getter
+public enum DummyGroup {
+    CLASSIC(
+            "클래식은 살아있다",
+            """
+                "모두가 알고 있다고 생각하지만, 제대로 읽은 사람은 많지 않은 이야기들."
+    
+                《로미오와 줄리엣》의 비극은 왜 오해와 조급함으로 가득했을까?
+                《이상한 나라의 앨리스》가 품은 무의식의 세계는 어떤 모습일까?
+                《프랑켄슈타인》의 괴물은 정말 괴물일까?
+    
+                우리는 누구나 제목은 알지만, 온전히 읽지 않았던 고전들을 다시 펼칩니다.
+                모임은 각 책의 배경, 작가의 삶, 시대적 맥락을 곁들여, 단순한 줄거리 이상의 것을 나누는 시간을 지향합니다.
+    
+                함께 읽고, 해석하고, 질문하면서
+                고전의 "그 너머"를 함께 탐험해요.
+                """,
+            "group-image/group-classic.png"
+            );
+    
+    DummyGroup(
+            String name, 
+            String description,
+            String groupImageKey
+    ) {
+        this.name = name;
+        this.description = description;
+        this.groupImageKey = groupImageKey;
+    }
+    
+    private final String name;
+    private final String description;
+    private final String groupImageKey;
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/init/dummy/DummyPublisher.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/init/dummy/DummyPublisher.java
@@ -1,0 +1,25 @@
+package qwerty.chaekit.global.init.dummy;
+
+import lombok.Getter;
+
+@Getter
+public enum DummyPublisher {
+    PUBLISHER1("publisher1@example.com", "출판사A", "profile-image/publisher1.webp)"),
+    PUBLISHER2("publisher2@example.com", "출판사B", "profile-image/publisher2.webp"),
+    PUBLISHER3("publisher3@example.com", "출판사C", "profile-image/publisher3.webp"),
+    ;
+    
+    DummyPublisher(
+            String email,
+            String publisherName,
+            String profileImageKey
+    ) {
+        this.email = email;
+        this.publisherName = publisherName;
+        this.profileImageKey = profileImageKey;
+    }
+    
+    private final String email;
+    private final String publisherName;
+    private final String profileImageKey;
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/global/init/dummy/DummyUser.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/global/init/dummy/DummyUser.java
@@ -1,0 +1,26 @@
+package qwerty.chaekit.global.init.dummy;
+
+import lombok.Getter;
+
+@Getter
+public enum DummyUser {
+    LEADER("user1@example.com", "모임지기", "profile-image/user1.webp"),
+    USER1("user2@example.com", "유저A", "profile-image/user2.webp"),
+    USER2("user3@example.com", "유저B", "profile-image/user3.webp"),
+    USER3("user4@example.com", "유저C", "profile-image/user4.webp"),
+    ;
+    
+    DummyUser(
+            String email,
+            String nickname,
+            String profileImageKey
+    ) {
+        this.email = email;
+        this.nickname = nickname;
+        this.profileImageKey = profileImageKey;
+    }
+    
+    private final String email;
+    private final String nickname;
+    private final String profileImageKey;
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/ebook/EbookService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/ebook/EbookService.java
@@ -33,12 +33,12 @@ public class EbookService {
     }
 
     public EbookFetchResponse fetchById(UserToken userToken, Long ebookId) {
-        UserProfile user = entityFinder.findUser(userToken.userId());
+        UserProfile user = userToken.isAnonymous() ? null : entityFinder.findUser(userToken.userId());
         Ebook ebook = entityFinder.findEbook(ebookId);
         return EbookFetchResponse.of(
                 ebook,
                 fileService.convertToPublicImageURL(ebook.getCoverImageKey()),
-                user.isPurchased(ebook)
+                user != null && user.isPurchased(ebook)
         );
     }
 }

--- a/chaekit-spring/src/main/resources/db/migration/V23__sizeup_highlightcontent.sql
+++ b/chaekit-spring/src/main/resources/db/migration/V23__sizeup_highlightcontent.sql
@@ -1,0 +1,1 @@
+ALTER TABLE highlight MODIFY COLUMN highlightcontent VARCHAR(1000); 


### PR DESCRIPTION
## ✨ 작업 개요
더미 데이터 자동 생성 기능 구현

## ✅ 작업 내용
- 기존 사용자, 출판사 더미 데이터 리팩토링
- S3에 수동 업로드(전자책, 전자책 커버, 그룹 이미지, 사용자 프로필)
- 전자책 더미 데이터 생성
- 그룹 더미 데이터 생성
- 사용자 더미 데이터 생성
- 출판사 더미 데이터 생성
- 길이 제한 @Valid 적용
- 비로그인에도 도서 정보 조회 가능하도록 수정

## 💬 기타
x
