### PR TITLE
[CHORE] UI 폴리싱

### DIFF
--- a/client/src/component/BookList.tsx
+++ b/client/src/component/BookList.tsx
@@ -141,7 +141,24 @@ function BookListItem(props: { book?: BookMetadata }) {
           <LinkCardActionArea to="/books/$bookId" params={{ bookId: book.id }}>
             <Typography variant="body2">{book.author}</Typography>
           </LinkCardActionArea>
-          <Typography variant="body2">{book.size} KB</Typography>
+          <Typography variant="body2" color="textSecondary">
+            {book.description.length > 50
+              ? book.description.slice(0, 128) + "..."
+              : book.description}
+          </Typography>
+          <Stack
+            direction="row"
+            justifyContent="flex-end"
+            alignItems={"center"}
+            spacing={2}
+          >
+            <Typography variant="body2" color="textSecondary">
+              {(book.size / 1024 / 1024).toFixed(1)} MiB
+            </Typography>
+            <Typography variant="body1" color="primary">
+              {book.price.toLocaleString()}원
+            </Typography>
+          </Stack>
         </Stack>
       </Stack>
     </Card>

--- a/client/src/component/_pathlessLayout/groups/$groupId/ActivityCard.tsx
+++ b/client/src/component/_pathlessLayout/groups/$groupId/ActivityCard.tsx
@@ -524,8 +524,16 @@ export function ActivityCreateModal(props: {
         }}
       >
         <Container maxWidth="md">
-          <Paper sx={{ width: "100%", height: "100%", padding: 4 }}>
-            <Stack spacing={2} sx={{ height: "100%", overflowY: "auto" }}>
+          <Paper
+            sx={{
+              width: "100%",
+              height: "100%",
+              padding: 4,
+              maxHeight: "90vh",
+              overflowY: "auto",
+            }}
+          >
+            <Stack spacing={2} sx={{ height: "100%" }}>
               <BookPicker
                 onBookPicked={(book) => {
                   setBook(book);

--- a/client/src/component/_pathlessLayout/groups/$groupId/GroupHeader.tsx
+++ b/client/src/component/_pathlessLayout/groups/$groupId/GroupHeader.tsx
@@ -9,13 +9,19 @@ import {
   Divider,
   Grid,
   Chip,
+  Popover,
+  Card,
+  Avatar,
+  Box,
 } from "@mui/material";
-import { People, Settings } from "@mui/icons-material";
+import { Group, Settings } from "@mui/icons-material";
 import { LinkIconButton } from "../../../../component/_pathlessLayout/groups/$groupId/LinkIconButton";
 import { GroupInfo, GroupMembershipStatus } from "../../../../types/groups";
 import API_CLIENT from "../../../../api/api";
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 
+const MEMBERS_SIZE = 2;
 interface GroupHeaderProps {
   group: GroupInfo | undefined;
   groupId: number;
@@ -23,6 +29,28 @@ interface GroupHeaderProps {
 
 export function GroupHeader({ group, groupId }: GroupHeaderProps) {
   const [joinGroupRequested, setJoinGroupRequested] = useState(false);
+  const [membersPopoverAnchorElement, setMembersPopoverAnchorElement] =
+    useState<HTMLButtonElement | null>(null);
+  const [hasMoreMembers, setHasMoreMembers] = useState(false);
+
+  const { data: members } = useQuery({
+    queryKey: ["groupMembers", groupId],
+    queryFn: async () => {
+      const response = await API_CLIENT.groupController.getGroupMembers(
+        groupId,
+        {
+          page: 0,
+          size: MEMBERS_SIZE,
+        }
+      );
+      if (!response.isSuccessful) {
+        throw new Error(response.errorMessage);
+      }
+      setHasMoreMembers((response.data.totalItems || 0) > MEMBERS_SIZE);
+      return response.data.content;
+    },
+    initialData: [],
+  });
 
   const onJoinButtonClicked = async () => {
     const response = await API_CLIENT.groupController.requestJoinGroup(groupId);
@@ -46,117 +74,174 @@ export function GroupHeader({ group, groupId }: GroupHeaderProps) {
     };
   };
 
+  const onMembersButtonClicked = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => {
+    setMembersPopoverAnchorElement(event.currentTarget);
+  };
+  const handleProgressPopoverClose = () => {
+    setMembersPopoverAnchorElement(null);
+  };
+
   if (!group) {
     return <GroupHeaderSkeleton />;
   }
 
   return (
-    <Paper sx={{ p: 2 }}>
-      <Stack spacing={2}>
-        <Stack direction={"row"} spacing={2}>
-          <Stack flexGrow={1}>
-            <Stack direction={"row"} spacing={2} flexGrow={1}>
-              <Stack>
-                {group ? (
-                  <CardMedia
-                    image={group.groupImageURL}
-                    sx={{ width: 256, height: 256 }}
-                  />
-                ) : (
-                  <Skeleton variant="rectangular" width={256} height={256} />
-                )}
-              </Stack>
-              <Stack sx={{ flexGrow: 1 }}>
-                <Stack direction={"row"} spacing={1}>
-                  <Typography variant="h3" flexGrow={1}>
-                    {group ? group.name : <Skeleton variant="text" />}
-                  </Typography>
-                  <Typography
-                    variant="body2"
-                    color="textSecondary"
-                    sx={{
-                      display: "flex",
-                      alignItems: "center",
-                    }}
+    <>
+      <Popover
+        open={!!membersPopoverAnchorElement}
+        anchorEl={membersPopoverAnchorElement}
+        onClose={handleProgressPopoverClose}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "left",
+        }}
+        disableRestoreFocus
+        slotProps={{
+          paper: {
+            sx: { p: 2, minWidth: 320 },
+          },
+        }}
+      >
+        <Typography variant="subtitle1" sx={{ mb: 1 }}>
+          모임 멤버
+        </Typography>
+        <Divider />
+        {members && members.length === 0 ? (
+          <Typography variant="body2">아직 멤버가 없습니다.</Typography>
+        ) : (
+          <Stack spacing={1} textAlign={"center"}>
+            {members &&
+              members.map((member) => (
+                <Card key={member.userId}>
+                  <Stack
+                    direction={"row"}
+                    spacing={1}
+                    alignItems={"center"}
+                    sx={{ p: 2 }}
                   >
-                    <Icon>
-                      <People />
-                    </Icon>
-                    {group ? group.memberCount : <Skeleton />}
-                  </Typography>
-                  {group.myMemberShipStatus === GroupMembershipStatus.OWNED && (
-                    <LinkIconButton
-                      to={"/groups/$groupId/manage"}
-                      params={{ groupId }}
-                      size="large"
-                      sx={{
-                        alignSelf: "center",
-                        justifySelf: "flex-end",
-                      }}
-                    >
-                      <Settings />
-                    </LinkIconButton>
+                    <Avatar src={member.profileImageURL} />
+                    <Typography variant="body2">{member.nickname!}</Typography>
+                  </Stack>
+                </Card>
+              ))}
+            {hasMoreMembers && (
+              <Box>
+                <Typography variant="body2" color="textSecondary">
+                  {`+ ${group.memberCount - (members?.length || 0)}`}
+                </Typography>
+              </Box>
+            )}
+          </Stack>
+        )}
+      </Popover>
+      <Paper sx={{ p: 2 }}>
+        <Stack spacing={2}>
+          <Stack direction={"row"} spacing={2}>
+            <Stack flexGrow={1}>
+              <Stack direction={"row"} spacing={2} flexGrow={1}>
+                <Stack>
+                  {group ? (
+                    <CardMedia
+                      image={group.groupImageURL}
+                      sx={{ width: 256, height: 256 }}
+                    />
+                  ) : (
+                    <Skeleton variant="rectangular" width={256} height={256} />
                   )}
                 </Stack>
-                <Typography variant="body1" flexGrow={1}>
-                  {group ? group.description : <Skeleton />}
-                </Typography>
-                {(group.myMemberShipStatus === GroupMembershipStatus.NONE ||
-                  group.myMemberShipStatus ===
-                    GroupMembershipStatus.PENDING) && (
-                  <Button
-                    onClick={onJoinButtonClicked}
-                    variant="contained"
-                    disabled={joinGroupRequested}
-                    sx={{
-                      justifySelf: "flex-end",
-                      alignSelf: "flex-end",
-                      width: "fit-content",
-                    }}
-                  >
-                    {group.myMemberShipStatus === GroupMembershipStatus.PENDING
-                      ? "가입 대기중"
-                      : "가입하기"}
-                  </Button>
-                )}
-                {group.myMemberShipStatus === GroupMembershipStatus.JOINED && (
-                  <Button
-                    variant="contained"
-                    color="error"
-                    onClick={onLeaveButtonClicked()}
-                    sx={{
-                      justifySelf: "flex-end",
-                      alignSelf: "flex-end",
-                      width: "fit-content",
-                    }}
-                  >
-                    모임 탈퇴하기
-                  </Button>
-                )}
+                <Stack sx={{ flexGrow: 1 }}>
+                  <Stack direction={"row"} spacing={1}>
+                    <Typography variant="h3" flexGrow={1}>
+                      {group ? group.name : <Skeleton variant="text" />}
+                    </Typography>
+                    <Button
+                      sx={{ ml: "auto", gap: 0.5 }}
+                      onClick={onMembersButtonClicked}
+                    >
+                      <Icon>
+                        <Group />
+                      </Icon>
+                      {group.memberCount}
+                    </Button>
+                    {group.myMemberShipStatus ===
+                      GroupMembershipStatus.OWNED && (
+                      <LinkIconButton
+                        to={"/groups/$groupId/manage"}
+                        params={{ groupId }}
+                        size="large"
+                        sx={{
+                          alignSelf: "center",
+                          justifySelf: "flex-end",
+                        }}
+                      >
+                        <Settings />
+                      </LinkIconButton>
+                    )}
+                  </Stack>
+                  <Typography variant="body1" flexGrow={1}>
+                    {group ? group.description : <Skeleton />}
+                  </Typography>
+                  {(group.myMemberShipStatus === GroupMembershipStatus.NONE ||
+                    group.myMemberShipStatus ===
+                      GroupMembershipStatus.PENDING) && (
+                    <Button
+                      onClick={onJoinButtonClicked}
+                      variant="contained"
+                      disabled={joinGroupRequested}
+                      sx={{
+                        justifySelf: "flex-end",
+                        alignSelf: "flex-end",
+                        width: "fit-content",
+                      }}
+                    >
+                      {group.myMemberShipStatus ===
+                      GroupMembershipStatus.PENDING
+                        ? "가입 대기중"
+                        : "가입하기"}
+                    </Button>
+                  )}
+                  {group.myMemberShipStatus ===
+                    GroupMembershipStatus.JOINED && (
+                    <Button
+                      variant="contained"
+                      color="error"
+                      onClick={onLeaveButtonClicked()}
+                      sx={{
+                        justifySelf: "flex-end",
+                        alignSelf: "flex-end",
+                        width: "fit-content",
+                      }}
+                    >
+                      모임 탈퇴하기
+                    </Button>
+                  )}
+                </Stack>
               </Stack>
             </Stack>
           </Stack>
+          <Divider />
+          <Grid container spacing={1}>
+            {group ? (
+              group.tags.map((tag) => {
+                return (
+                  <Chip
+                    key={tag}
+                    label={tag}
+                    onClick={() => {
+                      // TODO: move to search page with tag
+                    }}
+                  />
+                );
+              })
+            ) : (
+              <Skeleton width={128} />
+            )}
+          </Grid>
         </Stack>
-        <Divider />
-        <Grid container spacing={1}>
-          {group ? (
-            group.tags.map((tag) => {
-              return (
-                <Chip
-                  key={tag}
-                  label={tag}
-                  onClick={() => {
-                    // TODO: move to search page with tag
-                  }}
-                />
-              );
-            })
-          ) : (
-            <Skeleton width={128} />
-          )}
-        </Grid>
-      </Stack>
-    </Paper>
+      </Paper>
+    </>
   );
 }
 function GroupHeaderSkeleton() {

--- a/client/src/component/_pathlessLayout/groups/$groupId/GroupHeader.tsx
+++ b/client/src/component/_pathlessLayout/groups/$groupId/GroupHeader.tsx
@@ -142,19 +142,15 @@ export function GroupHeader({ group, groupId }: GroupHeaderProps) {
             <Stack flexGrow={1}>
               <Stack direction={"row"} spacing={2} flexGrow={1}>
                 <Stack>
-                  {group ? (
-                    <CardMedia
-                      image={group.groupImageURL}
-                      sx={{ width: 256, height: 256 }}
-                    />
-                  ) : (
-                    <Skeleton variant="rectangular" width={256} height={256} />
-                  )}
+                  <CardMedia
+                    image={group.groupImageURL}
+                    sx={{ width: 256, height: 256 }}
+                  />
                 </Stack>
-                <Stack sx={{ flexGrow: 1 }}>
+                <Stack spacing={2} sx={{ flexGrow: 1 }}>
                   <Stack direction={"row"} spacing={1}>
                     <Typography variant="h3" flexGrow={1}>
-                      {group ? group.name : <Skeleton variant="text" />}
+                      {group.name}
                     </Typography>
                     <Button
                       sx={{ ml: "auto", gap: 0.5 }}
@@ -180,8 +176,14 @@ export function GroupHeader({ group, groupId }: GroupHeaderProps) {
                       </LinkIconButton>
                     )}
                   </Stack>
+                  <Stack direction={"row"} spacing={1} alignItems={"center"}>
+                    <Avatar src={group.leaderProfileImageURL} />
+                    <Typography variant="body2">
+                      {group.leaderNickname}
+                    </Typography>
+                  </Stack>
                   <Typography variant="body1" flexGrow={1}>
-                    {group ? group.description : <Skeleton />}
+                    {group.description}
                   </Typography>
                   {(group.myMemberShipStatus === GroupMembershipStatus.NONE ||
                     group.myMemberShipStatus ===

--- a/client/src/routes/_pathlessLayout/admin/uploadBook.tsx
+++ b/client/src/routes/_pathlessLayout/admin/uploadBook.tsx
@@ -15,7 +15,7 @@ import { useMemo, useState } from "react";
 import API_CLIENT from "../../../api/api";
 import { Add } from "@mui/icons-material";
 
-const MAX_DESCRIPTION_LENGTH = 255;
+const MAX_DESCRIPTION_LENGTH = 10000;
 
 export const Route = createFileRoute("/_pathlessLayout/admin/uploadBook")({
   component: RouteComponent,
@@ -53,6 +53,7 @@ function RouteComponent() {
         setAuthor("");
         setDescription("");
         setCoverImageFile(null);
+        setPrice(0);
       }
     };
     inputElement.click();
@@ -64,8 +65,8 @@ function RouteComponent() {
   }, [coverImageFile]);
 
   return (
-    <Card>
-      <CardHeader title="Upload Book" />
+    <Card sx={{ p: 2 }}>
+      <CardHeader title="전자책 업로드" />
       <CardActionArea
         onClick={() => {
           const fileInput = document.createElement("input");
@@ -124,7 +125,9 @@ function RouteComponent() {
           placeholder="Description"
           multiline
           value={description}
-          inputProps={{ maxLength: MAX_DESCRIPTION_LENGTH }}
+          slotProps={{
+            htmlInput: { maxLength: MAX_DESCRIPTION_LENGTH },
+          }}
           onChange={(e) => {
             const value = e.target.value;
             if (value.length >= MAX_DESCRIPTION_LENGTH) {
@@ -141,9 +144,9 @@ function RouteComponent() {
         <TextField
           fullWidth
           placeholder="10000"
-          value={price}
+          value={price.toLocaleString()}
           onChange={(e) => {
-            const value = e.target.value;
+            const value = e.target.value.replace(/,/g, "");
             const parsedValue = parseInt(value);
             if (isNaN(parsedValue)) {
               return;
@@ -154,7 +157,6 @@ function RouteComponent() {
             }
             setPrice(parsedValue);
           }}
-          helperText={`${description.length} / ${MAX_DESCRIPTION_LENGTH}`}
         />
       </CardContent>
       <CardActions>

--- a/client/src/routes/_pathlessLayout/books/$bookId.tsx
+++ b/client/src/routes/_pathlessLayout/books/$bookId.tsx
@@ -1,4 +1,4 @@
-import { Divider } from "@mui/material";
+import { Divider, Skeleton } from "@mui/material";
 import {
   Button,
   CardMedia,
@@ -86,12 +86,14 @@ function RouteComponent() {
     setIsPurchased(true);
   };
 
+  if (isLoading) {
+    return <PlaceHolder />;
+  }
+
   return (
     <Container sx={{ my: 8 }}>
       <Paper sx={{ p: 4 }}>
-        {isLoading || !book ? (
-          <Typography>로딩 중...</Typography>
-        ) : (
+        {book && (
           <Stack direction={{ xs: "column", md: "row" }} spacing={4}>
             <CardMedia
               image={book.bookCoverImageURL}
@@ -140,32 +142,32 @@ function RouteComponent() {
               </Stack>
 
               <Stack spacing={2} direction="row" justifyContent="flex-end">
-                <Button
-                  variant="contained"
-                  onClick={handlePurchase}
-                  disabled={purchasing || isPurchased}
-                >
-                  {purchasing
-                    ? "구매 중..."
-                    : isPurchased
-                      ? "보유중"
-                      : "구매하기"}
-                </Button>
-                <LinkButton
-                  to="/reader/$bookId"
-                  params={{
-                    bookId,
-                  }}
-                  search={{
-                    groupId: undefined,
-                    activityId: undefined,
-                    temporalProgress: false,
-                    initialPage: readProgress?.cfi,
-                  }}
-                  variant="contained"
-                >
-                  {`도서 읽기${readProgress?.percentage ? ` (${readProgress.percentage}%)` : ""}`}
-                </LinkButton>
+                {!isPurchased && (
+                  <Button
+                    variant="contained"
+                    onClick={handlePurchase}
+                    disabled={purchasing || isPurchased}
+                  >
+                    {purchasing ? "구매 중..." : "구매하기"}
+                  </Button>
+                )}
+                {isPurchased && (
+                  <LinkButton
+                    to="/reader/$bookId"
+                    params={{
+                      bookId,
+                    }}
+                    search={{
+                      groupId: undefined,
+                      activityId: undefined,
+                      temporalProgress: false,
+                      initialPage: readProgress?.cfi,
+                    }}
+                    variant="contained"
+                  >
+                    {`도서 읽기${readProgress?.percentage ? ` (${readProgress.percentage}%)` : ""}`}
+                  </LinkButton>
+                )}
               </Stack>
             </Stack>
           </Stack>
@@ -179,6 +181,41 @@ function RouteComponent() {
           setOpenCreditPurchaseModal(false);
         }}
       />
+    </Container>
+  );
+}
+function PlaceHolder() {
+  return (
+    <Container sx={{ my: 8 }}>
+      <Paper sx={{ p: 4 }}>
+        <Stack direction={{ xs: "column", md: "row" }} spacing={4}>
+          <Skeleton
+            variant="rectangular"
+            width={192}
+            height={256}
+            sx={{ borderRadius: 2, mb: 2 }}
+          />
+          <Stack spacing={2} flex={1}>
+            <Skeleton variant="text" width="60%" height={48} />
+            <Skeleton variant="text" width="40%" height={32} />
+            <Divider />
+            <Skeleton variant="rectangular" width="100%" height={80} />
+            <Divider />
+            <Stack direction="row" spacing={2} alignItems="center">
+              <Skeleton variant="text" width={80} height={32} />
+              <Skeleton variant="text" width={120} height={40} />
+            </Stack>
+            <Stack direction="row" spacing={2} alignItems="center">
+              <Skeleton variant="text" width={80} height={32} />
+              <Skeleton variant="text" width={120} height={32} />
+            </Stack>
+            <Stack spacing={2} direction="row" justifyContent="flex-end">
+              <Skeleton variant="rectangular" width={120} height={40} />
+              <Skeleton variant="rectangular" width={120} height={40} />
+            </Stack>
+          </Stack>
+        </Stack>
+      </Paper>
     </Container>
   );
 }

--- a/client/src/types/groups.ts
+++ b/client/src/types/groups.ts
@@ -11,6 +11,9 @@ export type GroupInfo = {
   description: string;
   tags: string[];
   groupImageURL: string;
+  leaderId: number;
+  leaderNickname: string;
+  leaderProfileImageURL: string;
   myMemberShipStatus: GroupMembershipStatus;
   memberCount: number;
 };


### PR DESCRIPTION
## ✨ 작업 개요
UI 폴리싱

## ✅ 작업 내용
- [x] [전자책 등록] 전자책 소개 및 가격에 길이 제한 255 -> 10000
- [x] [전자책 페이지] 구매 완료시 구매버튼 비활성화, 구매하지 않았을 시, 읽기 버튼 비활성화
- [x] 활동 생성시, 책 소개글이 너무 길면 ui가 짤려버림
- [x] 서버에서 저장하는 책 용량 단위가 Byte인데 현재 KB로 표기. MB로 요약 하는 것이 좋을듯함
- [x] 그룹멤버 수 아이콘을 누르면 그룹 멤버 모두 볼 수 있는 ui (활동 멤버처럼)
- [x] 모임페이지에서 모임지기 프로필을 볼 수 있는 UI

## 📎 관련 이슈
Related #225 

## 🧪 테스트 방법

## 💬 기타
