### PR TITLE
[FEAT][BE] 메인 페이지용 api 추가 구현(통계, 모임 정렬 및 검색)

### DIFF
--- a/chaekit-spring/src/main/java/qwerty/chaekit/controller/group/GroupController.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/controller/group/GroupController.java
@@ -12,6 +12,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import qwerty.chaekit.dto.group.request.GroupPatchRequest;
 import qwerty.chaekit.dto.group.request.GroupPostRequest;
+import qwerty.chaekit.dto.group.request.GroupSortType;
 import qwerty.chaekit.dto.group.response.GroupFetchResponse;
 import qwerty.chaekit.dto.group.response.GroupJoinResponse;
 import qwerty.chaekit.dto.group.response.GroupMemberResponse;
@@ -22,6 +23,8 @@ import qwerty.chaekit.global.security.resolver.Login;
 import qwerty.chaekit.global.security.resolver.UserToken;
 import qwerty.chaekit.service.group.GroupMemberService;
 import qwerty.chaekit.service.group.GroupService;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/groups")
@@ -38,11 +41,19 @@ public class GroupController {
         return ApiSuccessResponse.of(groupService.createGroup(userToken, groupPostRequest));
     }
 
+    @Operation(
+            summary = "모임 목록 조회",
+            description = "모임 목록을 조회합니다. 태그로 필터링할 수 있습니다. " +
+                    "정렬 기준은 MEMBER_COUNT(가입자 수), CREATED_AT(최신 생성 순) 중 선택할 수 있습니다."
+    )
     @GetMapping
     public ApiSuccessResponse<PageResponse<GroupFetchResponse>> getAllGroups(
             @Parameter(hidden = true) @Login(required = false) UserToken userToken,
-            @ParameterObject Pageable pageable) {
-        return ApiSuccessResponse.of(groupService.getAllGroups(userToken, pageable));
+            @ParameterObject Pageable pageable,
+            @RequestParam(required = false) List<String> tags,
+            @RequestParam(required = false, defaultValue = "MEMBER_COUNT") GroupSortType sortBy
+    ) {
+        return ApiSuccessResponse.of(groupService.getAllGroups(userToken, pageable, tags, sortBy));
     }
 
     @GetMapping("/my/joined")

--- a/chaekit-spring/src/main/java/qwerty/chaekit/controller/statistics/StatisticsController.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/controller/statistics/StatisticsController.java
@@ -1,0 +1,27 @@
+package qwerty.chaekit.controller.statistics;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import qwerty.chaekit.dto.statistics.MainStatisticResponse;
+import qwerty.chaekit.global.response.ApiSuccessResponse;
+import qwerty.chaekit.service.statistics.StatisticsService;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/statistics")
+@RequiredArgsConstructor
+public class StatisticsController {
+    private final StatisticsService statisticsService;
+    @Operation(
+        summary = "모임 통계 조회",
+        description = "모임의 통계 정보를 조회합니다. 총 모임 수, 총 사용자 수, 총 전자책 수, 총 활동 수, 최근 한 달간 증가한 활동 수를 포함합니다."
+    )
+    @GetMapping
+    public ApiSuccessResponse<MainStatisticResponse> getMainStatistics() {
+        return ApiSuccessResponse.of(statisticsService.getMainStatistics());
+    }
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/ebook/repository/EbookRepository.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/ebook/repository/EbookRepository.java
@@ -18,4 +18,5 @@ public interface EbookRepository {
 
     Page<Ebook> findAllByPublisher(PublisherProfile publisher, Pageable pageable);
     void incrementViewCount(Long ebookId);
+    long count();
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/ebook/repository/EbookRepositoryImpl.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/ebook/repository/EbookRepositoryImpl.java
@@ -77,4 +77,9 @@ public class EbookRepositoryImpl implements EbookRepository {
     public void incrementViewCount(Long ebookId) {
         ebookJpaRepository.incrementViewCount(ebookId);
     }
+
+    @Override
+    public long count() {
+        return ebookJpaRepository.count();
+    }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/repository/ActivityRepository.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/activity/repository/ActivityRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import qwerty.chaekit.domain.group.activity.Activity;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,4 +20,6 @@ public interface ActivityRepository extends JpaRepository<Activity, Long> {
 
     @Query("SELECT a FROM Activity a INNER JOIN FETCH a.book WHERE a.id = :activityId")
     Optional<Activity> findByIdWithBook(@Param("activityId") Long activityId);
+
+    long countByCreatedAtAfter(LocalDateTime createdAtAfter);
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/repository/GroupRepository.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/group/repository/GroupRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import qwerty.chaekit.domain.group.ReadingGroup;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<ReadingGroup, Long> {
@@ -20,4 +21,39 @@ public interface GroupRepository extends JpaRepository<ReadingGroup, Long> {
     Page<ReadingGroup> findByGroupLeaderId(Long userId, Pageable pageable);
 
     boolean existsReadingGroupByName(@NotBlank String name);
+
+    // Querydsl을 사용하면 더 간단하게 처리할 수 있지만, 여기서는 JpaRepository를 유지하여 구현
+    @Query("""
+    SELECT g FROM ReadingGroup g
+    LEFT JOIN g.groupMembers gm WITH gm.accepted = true
+    JOIN g.groupTags t
+    WHERE t.tagName IN :tags
+    GROUP BY g
+    ORDER BY COUNT(gm) DESC
+    """)
+    Page<ReadingGroup> findAllByTagsInOrderByMemberCountDesc(
+            List<String> tags,
+            Pageable pageable
+    );
+
+    @Query("""
+    SELECT g FROM ReadingGroup g
+    LEFT JOIN g.groupMembers gm WITH gm.accepted = true
+    GROUP BY g
+    ORDER BY COUNT(gm) DESC
+    """)
+    Page<ReadingGroup> findAllInOrderByMemberCountDesc(Pageable pageable);
+
+    @Query("""
+    SELECT g FROM ReadingGroup g
+    JOIN g.groupTags t
+    WHERE t.tagName IN :tags
+    GROUP BY g
+    """)
+    Page<ReadingGroup> findAllByTagsIn(
+            List<String> tags,
+            Pageable pageable
+    );
+    
+    // Page<ReadingGroup> findAll(Pageable pageable);
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/request/GroupSortType.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/group/request/GroupSortType.java
@@ -1,0 +1,6 @@
+package qwerty.chaekit.dto.group.request;
+
+public enum GroupSortType {
+    MEMBER_COUNT,
+    CREATED_AT
+}

--- a/chaekit-spring/src/main/java/qwerty/chaekit/dto/statistics/MainStatisticResponse.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/dto/statistics/MainStatisticResponse.java
@@ -1,0 +1,9 @@
+package qwerty.chaekit.dto.statistics;
+
+public record MainStatisticResponse(
+    long totalGroups,
+    long totalUsers,
+    long totalEbooks,
+    long totalActivities,
+    long increasedActivities
+) { }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/group/GroupService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/group/GroupService.java
@@ -2,7 +2,9 @@ package qwerty.chaekit.service.group;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import qwerty.chaekit.domain.group.ReadingGroup;
@@ -12,6 +14,7 @@ import qwerty.chaekit.domain.highlight.repository.HighlightRepository;
 import qwerty.chaekit.domain.member.user.UserProfile;
 import qwerty.chaekit.dto.group.request.GroupPatchRequest;
 import qwerty.chaekit.dto.group.request.GroupPostRequest;
+import qwerty.chaekit.dto.group.request.GroupSortType;
 import qwerty.chaekit.dto.group.response.GroupFetchResponse;
 import qwerty.chaekit.dto.group.response.GroupPostResponse;
 import qwerty.chaekit.dto.page.PageResponse;
@@ -65,13 +68,31 @@ public class GroupService {
     }
 
     @Transactional(readOnly = true)
-    public PageResponse<GroupFetchResponse> getAllGroups(UserToken userToken, Pageable pageable) {
+    public PageResponse<GroupFetchResponse> getAllGroups(
+            UserToken userToken, 
+            Pageable pageable, 
+            List<String> tags,
+            GroupSortType sortBy
+    ) {
         boolean isAnonymous = userToken.isAnonymous();
         Long userId = isAnonymous ? null : userToken.userId();
 
-        Page<GroupFetchResponse> page = groupRepository.findAll(pageable)
-                .map(group -> groupMapper.toGroupFetchResponse(group, userId));
-        return PageResponse.of(page);
+        Page<ReadingGroup> page;
+        if (tags != null && !tags.isEmpty()) {
+            if (sortBy == GroupSortType.MEMBER_COUNT) {
+                page = groupRepository.findAllByTagsInOrderByMemberCountDesc(tags, pageable);
+            } else {
+                page = groupRepository.findAllByTagsIn(tags, getPageableByNewest(pageable));
+            }
+        } else { // no tags provided
+            if (sortBy == GroupSortType.MEMBER_COUNT) {
+                page = groupRepository.findAllInOrderByMemberCountDesc(pageable);
+            } else {
+                page = groupRepository.findAll(getPageableByNewest(pageable));
+            }
+        }
+        Page<GroupFetchResponse> responsePage = page.map(group -> groupMapper.toGroupFetchResponse(group, userId));
+        return PageResponse.of(responsePage);
     }
 
     @Transactional(readOnly = true)
@@ -173,5 +194,13 @@ public class GroupService {
             throw new BadRequestException(ErrorCode.INVALID_TAG_LIST);
         }
         return validTags;
+    }
+
+    private static Pageable getPageableByNewest(Pageable pageable) {
+        return PageRequest.of(
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                pageable.getSort().isEmpty() ? Sort.by(Sort.Order.desc("createdAt")) : pageable.getSort()
+        );
     }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/statistics/StatisticsService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/statistics/StatisticsService.java
@@ -1,0 +1,38 @@
+package qwerty.chaekit.service.statistics;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import qwerty.chaekit.domain.ebook.repository.EbookRepository;
+import qwerty.chaekit.domain.group.activity.repository.ActivityRepository;
+import qwerty.chaekit.domain.group.repository.GroupRepository;
+import qwerty.chaekit.domain.member.user.UserProfileRepository;
+import qwerty.chaekit.dto.statistics.MainStatisticResponse;
+
+import java.time.LocalDateTime;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class StatisticsService {
+    private final ActivityRepository activityRepository;
+    private final EbookRepository ebookRepository;
+    private final UserProfileRepository userProfileRepository;
+    private final GroupRepository groupRepository;
+
+    public MainStatisticResponse getMainStatistics() {
+        long totalGroups = groupRepository.count();
+        long totalUsers = userProfileRepository.count();
+        long totalEbooks = ebookRepository.count();
+        long totalActivities = activityRepository.count();
+        long increasedActivities = activityRepository.countByCreatedAtAfter(LocalDateTime.now().minusMonths(1));
+
+        return new MainStatisticResponse(
+            totalGroups,
+            totalUsers,
+            totalEbooks,
+            totalActivities,
+            increasedActivities
+        );
+    }
+}

--- a/chaekit-spring/src/test/java/qwerty/chaekit/service/group/GroupServiceTest.java
+++ b/chaekit-spring/src/test/java/qwerty/chaekit/service/group/GroupServiceTest.java
@@ -17,6 +17,7 @@ import qwerty.chaekit.domain.highlight.repository.HighlightRepository;
 import qwerty.chaekit.domain.member.user.UserProfile;
 import qwerty.chaekit.dto.group.request.GroupPatchRequest;
 import qwerty.chaekit.dto.group.request.GroupPostRequest;
+import qwerty.chaekit.dto.group.request.GroupSortType;
 import qwerty.chaekit.dto.group.response.GroupFetchResponse;
 import qwerty.chaekit.dto.group.response.GroupPostResponse;
 import qwerty.chaekit.dto.page.PageResponse;
@@ -126,7 +127,7 @@ class GroupServiceTest {
         when(groupMapper.toGroupFetchResponse(group, 1L)).thenReturn(fetchResponse);
 
         // When
-        PageResponse<GroupFetchResponse> response = groupService.getAllGroups(userToken, pageable);
+        PageResponse<GroupFetchResponse> response = groupService.getAllGroups(userToken, pageable, null, GroupSortType.CREATED_AT);
 
         // Then
         assertNotNull(response);


### PR DESCRIPTION
## ✨ 작업 개요
메인 페이지용 api 추가 구현

## ✅ 작업 내용
- 메인 페이지용 통계 제공
- 독서모임 조회시 모임원 수 정렬 옵션 추가
- 독서모임 조회시 태그 기반 검색 옵션 추가

## 📎 관련 이슈
Closes #262 
## 🧪 테스트 방법
POSTMAN

## 💬 기타

