### PR TITLE
Fix pagination count for activity progress

### DIFF
--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/ebook/ReadingProgressService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/ebook/ReadingProgressService.java
@@ -64,7 +64,7 @@ public class ReadingProgressService {
                 .map(activityMember -> activityMember.getUser().getId())
                 .stream().toList();
         List<EbookPurchase> purchaseList = ebookPurchaseRepository.findByUserIdInAndEbook(userIdList, activity.getBook());
-        Page<EbookPurchase> ebookPurchases = new PageImpl<>(purchaseList, pageable, activityMembers.getTotalElements());
+        Page<EbookPurchase> ebookPurchases = new PageImpl<>(purchaseList, pageable, purchaseList.size());
 
         return PageResponse.of(ebookPurchases.map(readingProgressMapper::toResponse));
     }


### PR DESCRIPTION
## Summary
- ensure `ReadingProgressService.getProgressFromActivity` uses actual purchase count for pagination

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6840359b49a08325861f96bf69712c08