### PR TITLE
Add recent highlights API

### DIFF
--- a/chaekit-spring/src/main/java/qwerty/chaekit/controller/group/ActivityController.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/controller/group/ActivityController.java
@@ -8,17 +8,22 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 import qwerty.chaekit.dto.group.activity.*;
+import qwerty.chaekit.dto.highlight.HighlightSummaryResponse;
 import qwerty.chaekit.dto.page.PageResponse;
 import qwerty.chaekit.global.response.ApiSuccessResponse;
 import qwerty.chaekit.global.security.resolver.Login;
 import qwerty.chaekit.global.security.resolver.UserToken;
 import qwerty.chaekit.service.group.ActivityService;
+import qwerty.chaekit.service.highlight.HighlightService;
+
+import java.util.List;
 
 @RestController
 @RequestMapping
 @RequiredArgsConstructor
 public class ActivityController {
     private final ActivityService activityService;
+    private final HighlightService highlightService;
 
     @PostMapping("/api/groups/{groupId}/activities")
     public ApiSuccessResponse<ActivityPostResponse> createActivity(@Login UserToken userToken,
@@ -87,5 +92,16 @@ public class ActivityController {
             @PathVariable long activityId
     ) {
         return ApiSuccessResponse.of(activityService.getActivityTop5Scores(activityId));
+    }
+
+    @Operation(
+            summary = "최근 메모 조회",
+            description = "특정 활동에 등록된 최신 하이라이트 5개를 조회합니다."
+    )
+    @GetMapping("/api/activities/{activityId}/highlights/recent")
+    public ApiSuccessResponse<List<HighlightSummaryResponse>> getRecentHighlights(
+            @PathVariable long activityId
+    ) {
+        return ApiSuccessResponse.of(highlightService.getActivityRecentHighlights(activityId));
     }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/highlight/repository/HighlightJpaRepository.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/highlight/repository/HighlightJpaRepository.java
@@ -12,4 +12,7 @@ public interface HighlightJpaRepository extends JpaRepository<Highlight, Long> {
     @Query("SELECT COUNT(h) FROM Highlight h WHERE h.id IN :ids and h.activity = :activity")
     long countByIdsAndActivity(List<Long> ids, Activity activity);
     List<Highlight> findByActivity_Group(ReadingGroup activityGroup);
+
+    // 최근 생성된 하이라이트 5개 조회
+    List<Highlight> findTop5ByActivityOrderByCreatedAtDesc(Activity activity);
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/highlight/repository/HighlightRepository.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/highlight/repository/HighlightRepository.java
@@ -19,4 +19,11 @@ public interface HighlightRepository {
     long countByIdsAndActivity(List<Long> ids, Activity activity);
     Page<Highlight> findByAuthor(UserProfile user, @Nullable Long bookId, Pageable pageable);
     List<Highlight> findByGroup(ReadingGroup group);
+
+    /**
+     * 최근 생성된 하이라이트 5개를 조회합니다.
+     * @param activity 활동 엔티티
+     * @return 최신순 하이라이트 목록
+     */
+    List<Highlight> findRecentByActivity(Activity activity);
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/domain/highlight/repository/HighlightRepositoryImpl.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/domain/highlight/repository/HighlightRepositoryImpl.java
@@ -104,4 +104,9 @@ public class HighlightRepositoryImpl implements HighlightRepository {
     public List<Highlight> findByGroup(ReadingGroup group) {
         return highlightJpaRepository.findByActivity_Group(group);
     }
+
+    @Override
+    public List<Highlight> findRecentByActivity(Activity activity) {
+        return highlightJpaRepository.findTop5ByActivityOrderByCreatedAtDesc(activity);
+    }
 }

--- a/chaekit-spring/src/main/java/qwerty/chaekit/service/highlight/HighlightService.java
+++ b/chaekit-spring/src/main/java/qwerty/chaekit/service/highlight/HighlightService.java
@@ -16,6 +16,7 @@ import qwerty.chaekit.domain.highlight.Highlight;
 import qwerty.chaekit.domain.highlight.repository.HighlightRepository;
 import qwerty.chaekit.domain.member.user.UserProfile;
 import qwerty.chaekit.dto.highlight.HighlightFetchResponse;
+import qwerty.chaekit.dto.highlight.HighlightSummaryResponse;
 import qwerty.chaekit.dto.highlight.HighlightPostRequest;
 import qwerty.chaekit.dto.highlight.HighlightPostResponse;
 import qwerty.chaekit.dto.highlight.HighlightPutRequest;
@@ -138,6 +139,19 @@ public class HighlightService {
                         dh -> dh.getHighlight().getId(),
                         Collectors.mapping(DiscussionHighlight::getDiscussion, Collectors.toList())
                 ));
+    }
+
+    @Transactional(readOnly = true)
+    public List<HighlightSummaryResponse> getActivityRecentHighlights(Long activityId) {
+        Activity activity = entityFinder.findActivity(activityId);
+        List<Highlight> highlights = highlightRepository.findRecentByActivity(activity);
+
+        return highlights.stream()
+                .map(highlight -> HighlightSummaryResponse.of(
+                        highlight,
+                        fileService.convertToPublicImageURL(highlight.getAuthor().getProfileImageKey())
+                ))
+                .toList();
     }
 
     @Transactional


### PR DESCRIPTION
## Summary
- show the 5 most recent highlights for an activity
- expose new `/api/activities/{activityId}/highlights/recent` endpoint

## Testing
- `./gradlew test` *(fails: Could not determine the dependencies of task :test)*

------
https://chatgpt.com/codex/tasks/task_e_684406fa91f88325a3824fe445a36048