### PR TITLE
[FIX] 메인 페이지 요약 카드 수정

### DIFF
--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -156,7 +156,7 @@ function StatsSection() {
     {
       icon: <TrendingUp />,
       number: homeStats.increasedActivities,
-      label: "이번 달 신규 모임",
+      label: "이번 달 신규 활동",
       color: theme.palette.warning.main,
     },
   ];


### PR DESCRIPTION
## ✨ 작업 개요
메인 페이지 요약 카드 수정

## ✅ 작업 내용
메인페이지에 표기 오류: 이번 달 신규 모임 → 이번 달 신규 활동

## 📎 관련 이슈

## 🧪 테스트 방법
ex) Postman으로 /api/join 요청

## 💬 기타
ex) 에러 메시지 형식은 ErrorResponse로 통일함
